### PR TITLE
Geo stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,56 @@ var stream = d3_geo.geoStream();
 
 <a href="#geoStream" name="geoStream">#</a> d3.<b>geoStream</b>()
 
-…
+<a name="stream" href="#stream">#</a> d3.geo.<b>stream</b>(<i>object</i>, <i>listener</i>)
+
+Streams the specified [GeoJSON](http://geojson.org) *object* to the specified stream *listener*. (Despite the name “stream”, these method calls are currently synchronous.) While both features and geometry objects are supported as input, the stream interface only describes the geometry, and thus additional feature properties are not visible to listeners.
+
+## Stream Listeners
+
+Stream listeners must implement several methods to traverse geometry. Listeners are inherently stateful; the meaning of a [point](#point) depends on whether the point is inside of a [line](#lineStart), and likewise a line is distinguished from a ring by a [polygon](#polygonStart).
+
+<a name="stream_point" href="#stream_point">#</a> listener.<b>point</b>(<i>x</i>, <i>y</i>[, <i>z</i>])
+
+Indicates a point with the specified coordinates *x* and *y* (and optionally *z*). The coordinate system is unspecified and implementation-dependent; for example, [projection streams](Geo-Projections#stream) require spherical coordinates in degrees as input. Outside the context of a polygon or line, a point indicates a point geometry object ([Point](http://www.geojson.org/geojson-spec.html#point) or [MultiPoint](http://www.geojson.org/geojson-spec.html#multipoint)). Within a line or polygon ring, the point indicates a control point.
+
+<a name="stream_lineStart" href="#stream_lineStart">#</a> listener.<b>lineStart</b>()
+
+Indicates the start of a line or ring. Within a polygon, indicates the start of a ring. The first ring of a polygon is the exterior ring, and is typically clockwise. Any subsequent rings indicate holes in the polygon, and are typically counterclockwise.
+
+<a name="stream_lineEnd" href="#stream_lineEnd">#</a> listener.<b>lineEnd</b>()
+
+Indicates the end of a line or ring. Within a polygon, indicates the end of a ring. Unlike GeoJSON, the redundant closing coordinate of a ring is *not* indicated via [point](#point), and instead is implied via lineEnd within a polygon. Thus, the given polygon input:
+
+```json
+{
+  "type": "Polygon",
+  "coordinates": [
+    [[0, 0], [1, 0], [1, 1], [0, 1], [0, 0]]
+  ]
+}
+```
+
+Will produce the following series of method calls on the listener:
+
+```js
+listener.polygonStart();
+listener.lineStart();
+listener.point(0, 0);
+listener.point(1, 0);
+listener.point(1, 1);
+listener.point(0, 1);
+listener.lineEnd();
+listener.polygonEnd();
+```
+
+<a name="stream_polygonStart" href="#stream_polygonStart">#</a> listener.<b>polygonStart</b>()
+
+Indicates the start of a polygon. The first line of a polygon indicates the exterior ring, and any subsequent lines indicate interior holes.
+
+<a name="stream_polygonEnd" href="#stream_polygonEnd">#</a> listener.<b>polygonEnd</b>()
+
+Indicates the end of a polygon.
+
+<a name="stream_sphere" href="#stream_sphere">#</a> listener.<b>sphere</b>()
+
+Indicates the sphere (the globe; the unit sphere centered at ⟨0,0,0⟩).

--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 export {version} from "./build/package";
+export {default as geoStream} from "./src/stream.js";

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,0 +1,69 @@
+function d3_geo_streamGeometry(geometry, listener) {
+  if (geometry && d3_geo_streamGeometryType.hasOwnProperty(geometry.type)) {
+    d3_geo_streamGeometryType[geometry.type](geometry, listener);
+  }
+}
+
+var d3_geo_streamObjectType = {
+  Feature: function(feature, listener) {
+    d3_geo_streamGeometry(feature.geometry, listener);
+  },
+  FeatureCollection: function(object, listener) {
+    var features = object.features, i = -1, n = features.length;
+    while (++i < n) d3_geo_streamGeometry(features[i].geometry, listener);
+  }
+};
+
+var d3_geo_streamGeometryType = {
+  Sphere: function(object, listener) {
+    listener.sphere();
+  },
+  Point: function(object, listener) {
+    object = object.coordinates;
+    listener.point(object[0], object[1], object[2]);
+  },
+  MultiPoint: function(object, listener) {
+    var coordinates = object.coordinates, i = -1, n = coordinates.length;
+    while (++i < n) object = coordinates[i], listener.point(object[0], object[1], object[2]);
+  },
+  LineString: function(object, listener) {
+    d3_geo_streamLine(object.coordinates, listener, 0);
+  },
+  MultiLineString: function(object, listener) {
+    var coordinates = object.coordinates, i = -1, n = coordinates.length;
+    while (++i < n) d3_geo_streamLine(coordinates[i], listener, 0);
+  },
+  Polygon: function(object, listener) {
+    d3_geo_streamPolygon(object.coordinates, listener);
+  },
+  MultiPolygon: function(object, listener) {
+    var coordinates = object.coordinates, i = -1, n = coordinates.length;
+    while (++i < n) d3_geo_streamPolygon(coordinates[i], listener);
+  },
+  GeometryCollection: function(object, listener) {
+    var geometries = object.geometries, i = -1, n = geometries.length;
+    while (++i < n) d3_geo_streamGeometry(geometries[i], listener);
+  }
+};
+
+function d3_geo_streamLine(coordinates, listener, closed) {
+  var i = -1, n = coordinates.length - closed, coordinate;
+  listener.lineStart();
+  while (++i < n) coordinate = coordinates[i], listener.point(coordinate[0], coordinate[1], coordinate[2]);
+  listener.lineEnd();
+}
+
+function d3_geo_streamPolygon(coordinates, listener) {
+  var i = -1, n = coordinates.length;
+  listener.polygonStart();
+  while (++i < n) d3_geo_streamLine(coordinates[i], listener, 1);
+  listener.polygonEnd();
+}
+
+export default function(object, listener) {
+  if (object && d3_geo_streamObjectType.hasOwnProperty(object.type)) {
+    d3_geo_streamObjectType[object.type](object, listener);
+  } else {
+    d3_geo_streamGeometry(object, listener);
+  }
+};

--- a/src/stream.js
+++ b/src/stream.js
@@ -1,69 +1,69 @@
-function d3_geo_streamGeometry(geometry, listener) {
-  if (geometry && d3_geo_streamGeometryType.hasOwnProperty(geometry.type)) {
-    d3_geo_streamGeometryType[geometry.type](geometry, listener);
+function streamGeometry(geometry, listener) {
+  if (geometry && streamGeometryType.hasOwnProperty(geometry.type)) {
+    streamGeometryType[geometry.type](geometry, listener);
   }
 }
 
-var d3_geo_streamObjectType = {
-  Feature: function(feature, listener) {
-    d3_geo_streamGeometry(feature.geometry, listener);
+var streamObjectType = {
+  Feature: function (feature, listener) {
+    streamGeometry(feature.geometry, listener);
   },
-  FeatureCollection: function(object, listener) {
+  FeatureCollection: function (object, listener) {
     var features = object.features, i = -1, n = features.length;
-    while (++i < n) d3_geo_streamGeometry(features[i].geometry, listener);
+    while (++i < n) streamGeometry(features[i].geometry, listener);
   }
 };
 
-var d3_geo_streamGeometryType = {
-  Sphere: function(object, listener) {
+var streamGeometryType = {
+  Sphere: function (object, listener) {
     listener.sphere();
   },
-  Point: function(object, listener) {
+  Point: function (object, listener) {
     object = object.coordinates;
     listener.point(object[0], object[1], object[2]);
   },
-  MultiPoint: function(object, listener) {
+  MultiPoint: function (object, listener) {
     var coordinates = object.coordinates, i = -1, n = coordinates.length;
     while (++i < n) object = coordinates[i], listener.point(object[0], object[1], object[2]);
   },
-  LineString: function(object, listener) {
-    d3_geo_streamLine(object.coordinates, listener, 0);
+  LineString: function (object, listener) {
+    streamLine(object.coordinates, listener, 0);
   },
-  MultiLineString: function(object, listener) {
+  MultiLineString: function (object, listener) {
     var coordinates = object.coordinates, i = -1, n = coordinates.length;
-    while (++i < n) d3_geo_streamLine(coordinates[i], listener, 0);
+    while (++i < n) streamLine(coordinates[i], listener, 0);
   },
-  Polygon: function(object, listener) {
-    d3_geo_streamPolygon(object.coordinates, listener);
+  Polygon: function (object, listener) {
+    streamPolygon(object.coordinates, listener);
   },
-  MultiPolygon: function(object, listener) {
+  MultiPolygon: function (object, listener) {
     var coordinates = object.coordinates, i = -1, n = coordinates.length;
-    while (++i < n) d3_geo_streamPolygon(coordinates[i], listener);
+    while (++i < n) streamPolygon(coordinates[i], listener);
   },
-  GeometryCollection: function(object, listener) {
+  GeometryCollection: function (object, listener) {
     var geometries = object.geometries, i = -1, n = geometries.length;
-    while (++i < n) d3_geo_streamGeometry(geometries[i], listener);
+    while (++i < n) streamGeometry(geometries[i], listener);
   }
 };
 
-function d3_geo_streamLine(coordinates, listener, closed) {
+function streamLine(coordinates, listener, closed) {
   var i = -1, n = coordinates.length - closed, coordinate;
   listener.lineStart();
   while (++i < n) coordinate = coordinates[i], listener.point(coordinate[0], coordinate[1], coordinate[2]);
   listener.lineEnd();
 }
 
-function d3_geo_streamPolygon(coordinates, listener) {
+function streamPolygon(coordinates, listener) {
   var i = -1, n = coordinates.length;
   listener.polygonStart();
-  while (++i < n) d3_geo_streamLine(coordinates[i], listener, 1);
+  while (++i < n) streamLine(coordinates[i], listener, 1);
   listener.polygonEnd();
 }
 
-export default function(object, listener) {
-  if (object && d3_geo_streamObjectType.hasOwnProperty(object.type)) {
-    d3_geo_streamObjectType[object.type](object, listener);
+export default function (object, listener) {
+  if (object && streamObjectType.hasOwnProperty(object.type)) {
+    streamObjectType[object.type](object, listener);
   } else {
-    d3_geo_streamGeometry(object, listener);
+    streamGeometry(object, listener);
   }
 }

--- a/src/stream.js
+++ b/src/stream.js
@@ -66,4 +66,4 @@ export default function(object, listener) {
   } else {
     d3_geo_streamGeometry(object, listener);
   }
-};
+}

--- a/test/stream-test.js
+++ b/test/stream-test.js
@@ -1,238 +1,238 @@
 var tape = require("tape"),
-    d3 = require("../");
-    
-tape("stream does not allow null input", function(test) {
-    try {
-        d3.geoStream(null);
-        test.pass();
-    } catch (e) {
-        test.fail("should not have thrown an error");
-    }
-    test.end();
-});
+  d3 = require("../");
 
-tape("stream ignores unknown types", function(test) {
-    d3.geoStream({type: "Unknown"}, {});
-    d3.geoStream({type: "Feature", geometry: {type: "Unknown"}}, {});
-    d3.geoStream({type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "Unknown"}}]}, {});
-    d3.geoStream({type: "GeometryCollection", geometries: [{type: "Unknown"}]}, {});
+tape("stream does not allow null input", function (test) {
+  try {
+    d3.geoStream(null);
     test.pass();
-    test.end();
+  } catch (e) {
+    test.fail("should not have thrown an error");
+  }
+  test.end();
 });
 
-tape("stream ignores null geometries", function(test) {
-    d3.geoStream(null, {});
-    d3.geoStream({type: "Feature", geometry: null}, {});
-    d3.geoStream({type: "FeatureCollection", features: [{type: "Feature", geometry: null}]}, {});
-    d3.geoStream({type: "GeometryCollection", geometries: [null]}, {});
-    test.pass();
-    test.end();
+tape("stream ignores unknown types", function (test) {
+  d3.geoStream({ type: "Unknown" }, {});
+  d3.geoStream({ type: "Feature", geometry: { type: "Unknown" } }, {});
+  d3.geoStream({ type: "FeatureCollection", features: [{ type: "Feature", geometry: { type: "Unknown" } }] }, {});
+  d3.geoStream({ type: "GeometryCollection", geometries: [{ type: "Unknown" }] }, {});
+  test.pass();
+  test.end();
 });
 
-tape("stream returns void", function(test) {
-    test.isEqual(d3.geoStream({type: "Point", coordinates: [1, 2]}, {point: function() { return true; }}), undefined);
-    test.end();
+tape("stream ignores null geometries", function (test) {
+  d3.geoStream(null, {});
+  d3.geoStream({ type: "Feature", geometry: null }, {});
+  d3.geoStream({ type: "FeatureCollection", features: [{ type: "Feature", geometry: null }] }, {});
+  d3.geoStream({ type: "GeometryCollection", geometries: [null] }, {});
+  test.pass();
+  test.end();
 });
 
-tape("stream allows empty multi-geometries", function(test) {
-    d3.geoStream({type: "MultiPoint", coordinates: []}, {});
-    d3.geoStream({type: "MultiLineString", coordinates: []}, {});
-    d3.geoStream({type: "MultiPolygon", coordinates: []}, {});
-    test.pass();
-    test.end();
+tape("stream returns void", function (test) {
+  test.isEqual(d3.geoStream({ type: "Point", coordinates: [1, 2] }, { point: function () { return true; } }), undefined);
+  test.end();
 });
 
-tape("Sphere ↦ sphere", function(test) {
-    var calls = 0;
-    d3.geoStream({type: "Sphere"}, {
-    sphere: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls, 1);
+tape("stream allows empty multi-geometries", function (test) {
+  d3.geoStream({ type: "MultiPoint", coordinates: [] }, {});
+  d3.geoStream({ type: "MultiLineString", coordinates: [] }, {});
+  d3.geoStream({ type: "MultiPolygon", coordinates: [] }, {});
+  test.pass();
+  test.end();
+});
+
+tape("Sphere ↦ sphere", function (test) {
+  var calls = 0;
+  d3.geoStream({ type: "Sphere" }, {
+    sphere: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls, 1);
     }
-    });
-    test.isEqual(calls, 1);
-    test.end();
+  });
+  test.isEqual(calls, 1);
+  test.end();
 });
 
-tape("Point ↦ point", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "Point", coordinates: [1, 2, 3]}, {
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(++calls, 1);
+tape("Point ↦ point", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "Point", coordinates: [1, 2, 3] }, {
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(++calls, 1);
     }
-    });
-    test.isEqual(calls, 1);
-    test.end();
+  });
+  test.isEqual(calls, 1);
+  test.end();
 });
 
-tape("MultiPoint ↦ point*", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "MultiPoint", coordinates: [[1, 2, 3], [4, 5, 6]]}, {
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(1 <= ++calls && calls <= 2, true);
+tape("MultiPoint ↦ point*", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "MultiPoint", coordinates: [[1, 2, 3], [4, 5, 6]] }, {
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(1 <= ++calls && calls <= 2, true);
     }
-    });
-    test.isEqual(calls, 2);
-    test.end();
+  });
+  test.isEqual(calls, 2);
+  test.end();
 });
 
-tape("LineString ↦ lineStart, point{2,}, lineEnd", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "LineString", coordinates: [[1, 2, 3], [4, 5, 6]]}, {
-    lineStart: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls, 1);
+tape("LineString ↦ lineStart, point{2,}, lineEnd", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "LineString", coordinates: [[1, 2, 3], [4, 5, 6]] }, {
+    lineStart: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls, 1);
     },
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(2 <= ++calls && calls <= 3, true);
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(2 <= ++calls && calls <= 3, true);
     },
-    lineEnd: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls, 4);
+    lineEnd: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls, 4);
     }
-    });
-    test.isEqual(calls, 4);
-    test.end();
+  });
+  test.isEqual(calls, 4);
+  test.end();
 });
 
-tape("MultiLineString ↦ (lineStart, point{2,}, lineEnd)*", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "MultiLineString", coordinates: [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]}, {
-    lineStart: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 1 || calls === 5, true);
+tape("MultiLineString ↦ (lineStart, point{2,}, lineEnd)*", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "MultiLineString", coordinates: [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]] }, {
+    lineStart: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 1 || calls === 5, true);
     },
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(2 <= ++calls && calls <= 3 || 6 <= calls && calls <= 7, true);
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(2 <= ++calls && calls <= 3 || 6 <= calls && calls <= 7, true);
     },
-    lineEnd: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 4 || calls === 8, true);
+    lineEnd: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 4 || calls === 8, true);
     }
-    });
-    test.isEqual(calls, 8);
-    test.end();
+  });
+  test.isEqual(calls, 8);
+  test.end();
 });
 
-tape("Polygon ↦ polygonStart, lineStart, point{2,}, lineEnd, polygonEnd", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "Polygon", coordinates: [[[1, 2, 3], [4, 5, 6], [1, 2, 3]], [[7, 8, 9], [10, 11, 12], [7, 8, 9]]]}, {
-    polygonStart: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 1, true);
+tape("Polygon ↦ polygonStart, lineStart, point{2,}, lineEnd, polygonEnd", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "Polygon", coordinates: [[[1, 2, 3], [4, 5, 6], [1, 2, 3]], [[7, 8, 9], [10, 11, 12], [7, 8, 9]]] }, {
+    polygonStart: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 1, true);
     },
-    lineStart: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 2 || calls === 6, true);
+    lineStart: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 2 || calls === 6, true);
     },
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(3 <= ++calls && calls <= 4 || 7 <= calls && calls <= 8, true);
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(3 <= ++calls && calls <= 4 || 7 <= calls && calls <= 8, true);
     },
-    lineEnd: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 5 || calls === 9, true);
+    lineEnd: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 5 || calls === 9, true);
     },
-    polygonEnd: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 10, true);
+    polygonEnd: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 10, true);
     }
-    });
-    test.isEqual(calls, 10);
-    test.end();
+  });
+  test.isEqual(calls, 10);
+  test.end();
 });
 
-tape("MultiPolygon ↦ (polygonStart, lineStart, point{2,}, lineEnd, polygonEnd)*", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "MultiPolygon", coordinates: [[[[1, 2, 3], [4, 5, 6], [1, 2, 3]]], [[[7, 8, 9], [10, 11, 12], [7, 8, 9]]]]}, {
-    polygonStart: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 1 || calls === 7, true);
+tape("MultiPolygon ↦ (polygonStart, lineStart, point{2,}, lineEnd, polygonEnd)*", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "MultiPolygon", coordinates: [[[[1, 2, 3], [4, 5, 6], [1, 2, 3]]], [[[7, 8, 9], [10, 11, 12], [7, 8, 9]]]] }, {
+    polygonStart: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 1 || calls === 7, true);
     },
-    lineStart: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 2 || calls === 8, true);
+    lineStart: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 2 || calls === 8, true);
     },
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(3 <= ++calls && calls <= 4 || 9 <= calls && calls <= 10, true);
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(3 <= ++calls && calls <= 4 || 9 <= calls && calls <= 10, true);
     },
-    lineEnd: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 5 || calls === 11, true);
+    lineEnd: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 5 || calls === 11, true);
     },
-    polygonEnd: function() {
-        test.isEqual(arguments.length, 0);
-        test.isEqual(++calls === 6 || calls === 12, true);
+    polygonEnd: function () {
+      test.isEqual(arguments.length, 0);
+      test.isEqual(++calls === 6 || calls === 12, true);
     }
-    });
-    test.isEqual(calls, 12);
-    test.end();
+  });
+  test.isEqual(calls, 12);
+  test.end();
 });
 
-tape("Feature ↦ .*", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "Feature", geometry: {type: "Point", coordinates: [1, 2, 3]}}, {
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(++calls, 1);
+tape("Feature ↦ .*", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "Feature", geometry: { type: "Point", coordinates: [1, 2, 3] } }, {
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(++calls, 1);
     }
-    });
-    test.isEqual(calls, 1);
-    test.end();
+  });
+  test.isEqual(calls, 1);
+  test.end();
 });
 
-tape("FeatureCollection ↦ .*", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "Point", coordinates: [1, 2, 3]}}]}, {
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(++calls, 1);
+tape("FeatureCollection ↦ .*", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "FeatureCollection", features: [{ type: "Feature", geometry: { type: "Point", coordinates: [1, 2, 3] } }] }, {
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(++calls, 1);
     }
-    });
-    test.isEqual(calls, 1);
-    test.end();
+  });
+  test.isEqual(calls, 1);
+  test.end();
 });
 
-tape("GeometryCollection ↦ .*", function(test) {
-    var calls = 0, coordinates = 0;
-    d3.geoStream({type: "GeometryCollection", geometries: [{type: "Point", coordinates: [1, 2, 3]}]}, {
-    point: function(x, y, z) {
-        test.isEqual(arguments.length, 3);
-        test.isEqual(x, ++coordinates);
-        test.isEqual(y, ++coordinates);
-        test.isEqual(z, ++coordinates);
-        test.isEqual(++calls, 1);
+tape("GeometryCollection ↦ .*", function (test) {
+  var calls = 0, coordinates = 0;
+  d3.geoStream({ type: "GeometryCollection", geometries: [{ type: "Point", coordinates: [1, 2, 3] }] }, {
+    point: function (x, y, z) {
+      test.isEqual(arguments.length, 3);
+      test.isEqual(x, ++coordinates);
+      test.isEqual(y, ++coordinates);
+      test.isEqual(z, ++coordinates);
+      test.isEqual(++calls, 1);
     }
-    });
-    test.isEqual(calls, 1);
-    test.end();
+  });
+  test.isEqual(calls, 1);
+  test.end();
 });

--- a/test/stream-test.js
+++ b/test/stream-test.js
@@ -4,9 +4,9 @@ var tape = require("tape"),
 tape("stream does not allow null input", function(test) {
     try {
         d3.geoStream(null);
-        test.fail("expected error");
-    } catch (expected) {
         test.pass();
+    } catch (e) {
+        test.fail("should not have thrown an error");
     }
     test.end();
 });

--- a/test/stream-test.js
+++ b/test/stream-test.js
@@ -30,7 +30,7 @@ tape("stream ignores null geometries", function(test) {
 });
 
 tape("stream returns void", function(test) {
-    test.is(d3.geoStream({type: "Point", coordinates: [1, 2]}, {point: function() { return true; }}), undefined);
+    test.isEqual(d3.geoStream({type: "Point", coordinates: [1, 2]}, {point: function() { return true; }}), undefined);
     test.end();
 });
 
@@ -39,5 +39,200 @@ tape("stream allows empty multi-geometries", function(test) {
     d3.geoStream({type: "MultiLineString", coordinates: []}, {});
     d3.geoStream({type: "MultiPolygon", coordinates: []}, {});
     test.pass();
+    test.end();
+});
+
+tape("Sphere ↦ sphere", function(test) {
+    var calls = 0;
+    d3.geoStream({type: "Sphere"}, {
+    sphere: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls, 1);
+    }
+    });
+    test.isEqual(calls, 1);
+    test.end();
+});
+
+tape("Point ↦ point", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "Point", coordinates: [1, 2, 3]}, {
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(++calls, 1);
+    }
+    });
+    test.isEqual(calls, 1);
+    test.end();
+});
+
+tape("MultiPoint ↦ point*", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "MultiPoint", coordinates: [[1, 2, 3], [4, 5, 6]]}, {
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(1 <= ++calls && calls <= 2, true);
+    }
+    });
+    test.isEqual(calls, 2);
+    test.end();
+});
+
+tape("LineString ↦ lineStart, point{2,}, lineEnd", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "LineString", coordinates: [[1, 2, 3], [4, 5, 6]]}, {
+    lineStart: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls, 1);
+    },
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(2 <= ++calls && calls <= 3, true);
+    },
+    lineEnd: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls, 4);
+    }
+    });
+    test.isEqual(calls, 4);
+    test.end();
+});
+
+tape("MultiLineString ↦ (lineStart, point{2,}, lineEnd)*", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "MultiLineString", coordinates: [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]}, {
+    lineStart: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 1 || calls === 5, true);
+    },
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(2 <= ++calls && calls <= 3 || 6 <= calls && calls <= 7, true);
+    },
+    lineEnd: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 4 || calls === 8, true);
+    }
+    });
+    test.isEqual(calls, 8);
+    test.end();
+});
+
+tape("Polygon ↦ polygonStart, lineStart, point{2,}, lineEnd, polygonEnd", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "Polygon", coordinates: [[[1, 2, 3], [4, 5, 6], [1, 2, 3]], [[7, 8, 9], [10, 11, 12], [7, 8, 9]]]}, {
+    polygonStart: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 1, true);
+    },
+    lineStart: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 2 || calls === 6, true);
+    },
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(3 <= ++calls && calls <= 4 || 7 <= calls && calls <= 8, true);
+    },
+    lineEnd: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 5 || calls === 9, true);
+    },
+    polygonEnd: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 10, true);
+    }
+    });
+    test.isEqual(calls, 10);
+    test.end();
+});
+
+tape("MultiPolygon ↦ (polygonStart, lineStart, point{2,}, lineEnd, polygonEnd)*", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "MultiPolygon", coordinates: [[[[1, 2, 3], [4, 5, 6], [1, 2, 3]]], [[[7, 8, 9], [10, 11, 12], [7, 8, 9]]]]}, {
+    polygonStart: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 1 || calls === 7, true);
+    },
+    lineStart: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 2 || calls === 8, true);
+    },
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(3 <= ++calls && calls <= 4 || 9 <= calls && calls <= 10, true);
+    },
+    lineEnd: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 5 || calls === 11, true);
+    },
+    polygonEnd: function() {
+        test.isEqual(arguments.length, 0);
+        test.isEqual(++calls === 6 || calls === 12, true);
+    }
+    });
+    test.isEqual(calls, 12);
+    test.end();
+});
+
+tape("Feature ↦ .*", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "Feature", geometry: {type: "Point", coordinates: [1, 2, 3]}}, {
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(++calls, 1);
+    }
+    });
+    test.isEqual(calls, 1);
+    test.end();
+});
+
+tape("FeatureCollection ↦ .*", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "Point", coordinates: [1, 2, 3]}}]}, {
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(++calls, 1);
+    }
+    });
+    test.isEqual(calls, 1);
+    test.end();
+});
+
+tape("GeometryCollection ↦ .*", function(test) {
+    var calls = 0, coordinates = 0;
+    d3.geoStream({type: "GeometryCollection", geometries: [{type: "Point", coordinates: [1, 2, 3]}]}, {
+    point: function(x, y, z) {
+        test.isEqual(arguments.length, 3);
+        test.isEqual(x, ++coordinates);
+        test.isEqual(y, ++coordinates);
+        test.isEqual(z, ++coordinates);
+        test.isEqual(++calls, 1);
+    }
+    });
+    test.isEqual(calls, 1);
     test.end();
 });

--- a/test/stream-test.js
+++ b/test/stream-test.js
@@ -1,0 +1,43 @@
+var tape = require("tape"),
+    d3 = require("../");
+    
+tape("stream does not allow null input", function(test) {
+    try {
+        d3.geoStream(null);
+        test.fail("expected error");
+    } catch (expected) {
+        test.pass();
+    }
+    test.end();
+});
+
+tape("stream ignores unknown types", function(test) {
+    d3.geoStream({type: "Unknown"}, {});
+    d3.geoStream({type: "Feature", geometry: {type: "Unknown"}}, {});
+    d3.geoStream({type: "FeatureCollection", features: [{type: "Feature", geometry: {type: "Unknown"}}]}, {});
+    d3.geoStream({type: "GeometryCollection", geometries: [{type: "Unknown"}]}, {});
+    test.pass();
+    test.end();
+});
+
+tape("stream ignores null geometries", function(test) {
+    d3.geoStream(null, {});
+    d3.geoStream({type: "Feature", geometry: null}, {});
+    d3.geoStream({type: "FeatureCollection", features: [{type: "Feature", geometry: null}]}, {});
+    d3.geoStream({type: "GeometryCollection", geometries: [null]}, {});
+    test.pass();
+    test.end();
+});
+
+tape("stream returns void", function(test) {
+    test.is(d3.geoStream({type: "Point", coordinates: [1, 2]}, {point: function() { return true; }}), undefined);
+    test.end();
+});
+
+tape("stream allows empty multi-geometries", function(test) {
+    d3.geoStream({type: "MultiPoint", coordinates: []}, {});
+    d3.geoStream({type: "MultiLineString", coordinates: []}, {});
+    d3.geoStream({type: "MultiPolygon", coordinates: []}, {});
+    test.pass();
+    test.end();
+});


### PR DESCRIPTION
I just got legal approval for the Contributor Agreement, so here's my first contribution!

In reference to Issue #7, this PR contains the implementation of `d3.geoStream`, ported over from the v3.5.17 release of `d3/d3`.Tests have been ported to `tape` and relevant documentation has been brought over as well.

One thing to note: The first test in the `stream` suite was passing in v3.5.17 because the `assert.fail()` was throwing an error which was then caught by the `try` block. I rewrote that test in a way that I think preserves the intent, but it could probably use a second look.