### PR TITLE
Geo rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ Returns the great-arc length of the specified *feature* in [radians](http://math
 
 <a name="geoRotation" href="#geoRotation">#</a> d3.<b>geoRotation</b>(<i>angles</i>)
 
-… TODO I’m not sure we want to have this anymore? Rotation may be in d3-geo-projection.
+Specifies a rotation in the form of an array, [λ, φ, γ]. The elements of the array are angles in degrees, and specify a rotation in the following order: longitudinal, latitudinal and about the origin. If the last element of the array, γ, is omitted, this defaults to 0.  Returns a function, which rotates a given location as described below.
+
+<a name="_rotation" href="#_rotation">#</a> <b>rotation</b>(<i>location</i>)
+
+Rotates a given location according to the angles specified for this rotation, in the order described above.  A location is specified as an array [<i>longitude</i>, <i>latitude</i>], with coordinates expressed in degrees.  Returns a new array representing the rotated location.
+
+<a name="rotation_invert" href="#rotation_invert">#</a> rotation.<b>invert</b>(<i>location</i>)
+
+Rotates a given location according to the angles specified for this rotation, but with the order described above reversed.  A location is specified as an array [<i>longitude</i>, <i>latitude</i>], with coordinates expressed in degrees.  Returns a new array representing the rotated location.
 
 ### Shapes
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 export {version} from "./build/package";
 export {default as geoLength} from "./src/length";
+export {default as geoRotation} from "./src/rotation";
 export {default as geoStream} from "./src/stream";

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,0 +1,12 @@
+export default function(a, b) {
+
+  function compose(x, y) {
+    return x = a(x, y), b(x[0], x[1]);
+  }
+
+  if (a.invert && b.invert) compose.invert = function(x, y) {
+    return x = b.invert(x, y), x && a.invert(x[0], x[1]);
+  };
+
+  return compose;
+}

--- a/src/rotation.js
+++ b/src/rotation.js
@@ -1,0 +1,77 @@
+import compose from "./compose";
+import {deg2rad, rad2deg} from "./math";
+
+function identityRotation(lambda, phi) {
+  return [lambda > Math.PI ? lambda - 2*Math.PI : lambda < -Math.PI ? lambda + 2*Math.PI : lambda, phi];
+}
+
+identityRotation.invert = identityRotation;
+
+// Note: |deltaLambda| must be < 2pi
+function rotation(deltaLambda, deltaPhi, deltaGamma) {
+  return deltaLambda ? (deltaPhi || deltaGamma ? compose(rotationLambda(deltaLambda), rotationPhiGamma(deltaPhi, deltaGamma))
+    : rotationLambda(deltaLambda))
+    : (deltaPhi || deltaGamma ? rotationPhiGamma(deltaPhi, deltaGamma)
+    : identityRotation);
+}
+
+function forwardRotationLambda(deltaLambda) {
+  return function(lambda, phi) {
+    return lambda += deltaLambda, [lambda > Math.PI ? lambda - 2*Math.PI : lambda < -Math.PI ? lambda + 2*Math.PI : lambda, phi];
+  };
+}
+
+function rotationLambda(deltaLambda) {
+  var rotation = forwardRotationLambda(deltaLambda);
+  rotation.invert = forwardRotationLambda(-deltaLambda);
+  return rotation;
+}
+
+function rotationPhiGamma(deltaPhi, deltaGamma) {
+  var cosDeltaPhi = Math.cos(deltaPhi),
+      sinDeltaPhi = Math.sin(deltaPhi),
+      cosDeltaGamma = Math.cos(deltaGamma),
+      sinDeltaGamma = Math.sin(deltaGamma);
+
+  function rotation(lambda, phi) {
+    var cosPhi = Math.cos(phi),
+        x = Math.cos(lambda) * cosPhi,
+        y = Math.sin(lambda) * cosPhi,
+        z = Math.sin(phi),
+        k = z * cosDeltaPhi + x * sinDeltaPhi;
+    return [
+      Math.atan2(y * cosDeltaGamma - k * sinDeltaGamma, x * cosDeltaPhi - z * sinDeltaPhi),
+      Math.asin(k * cosDeltaGamma + y * sinDeltaGamma)
+    ];
+  }
+
+  rotation.invert = function(lambda, phi) {
+    var cosPhi = Math.cos(phi),
+        x = Math.cos(lambda) * cosPhi,
+        y = Math.sin(lambda) * cosPhi,
+        z = Math.sin(phi),
+        k = z * cosDeltaGamma - y * sinDeltaGamma;
+    return [
+      Math.atan2(y * cosDeltaGamma + z * sinDeltaGamma, x * cosDeltaPhi + k * sinDeltaPhi),
+      Math.asin(k * cosDeltaPhi - x * sinDeltaPhi)
+    ];
+  };
+
+  return rotation;
+}
+
+export default function(rotate) {
+  rotate = rotation(rotate[0] % 360 * deg2rad, rotate[1] * deg2rad, rotate.length > 2 ? rotate[2] * deg2rad : 0);
+
+  function forward(coordinates) {
+    coordinates = rotate(coordinates[0] * deg2rad, coordinates[1] * deg2rad);
+    return coordinates[0] *= rad2deg, coordinates[1] *= rad2deg, coordinates;
+  }
+
+  forward.invert = function(coordinates) {
+    coordinates = rotate.invert(coordinates[0] * deg2rad, coordinates[1] * deg2rad);
+    return coordinates[0] *= rad2deg, coordinates[1] *= rad2deg, coordinates;
+  };
+
+  return forward;
+}

--- a/test/rotation-test.js
+++ b/test/rotation-test.js
@@ -1,0 +1,33 @@
+var tape = require("tape"),
+    d3 = require("../");
+  
+require("./inDelta");
+
+tape("a rotation of [+90°, 0°] only rotates longitude", function(test) {
+  var rotation = d3.geoRotation([90, 0])([0, 0]);
+  test.inDelta(rotation[0], 90, 1e-6);
+  test.inDelta(rotation[1], 0, 1e-6);
+  test.end();
+});
+
+tape("a rotation of [+90°, 0°] wraps around when crossing the antimeridian", function(test) {
+  var rotation = d3.geoRotation([90, 0])([150, 0]);
+  test.inDelta(rotation[0], -120, 1e-6);
+  test.inDelta(rotation[1], 0, 1e-6);
+  test.end();
+});
+
+tape("a rotation of [-45°, -45°] rotates longitude and latitude", function(test) {
+  var rotation = d3.geoRotation([-45, 45])([0, 0]);
+  test.inDelta(rotation[0], -54.73561, 1e-6);
+  test.inDelta(rotation[1], 30, 1e-6);
+  test.end();
+});
+
+tape("a rotation of [-45°, -45°] inverse rotation of longitude and latitude", function(test) {
+  var rotation = d3.geoRotation([-45, 45]).invert([-54.73561, 30]);
+  test.inDelta(rotation[0], 0, 1e-6);
+  test.inDelta(rotation[1], 0, 1e-6);
+  test.end();
+});
+      


### PR DESCRIPTION
(Note: Now that some of the common structure has been laid out, I've published 4 orthogonal branches. These can be reviewed and merged in any order, whenever you see fit. There might be slight merge conflicts around index.js, but that should be all.)

This branch addresses Issue #13 , `d3.geoRotation`.

I followed your advice and swapped out `equirectangular`, which successfully solved the circular dependency. I'll look into a similar solution for getting the references to `spherical` out of `d3.geoCircle`.