### PR TITLE
Add geoTile

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ var path = d3.geoPath();
 * [Shapes](#shapes)
 * [Projections](#projections)
 * [Transforms](#transforms)
+* [Tile](#tile)
 
 ### Math
 
@@ -362,3 +363,37 @@ function matrix(a, b, c, d, tx, ty) {
   });
 }
 ```
+
+### Tile
+
+<a href="#geoTile" name="geoTile">#</a> d3.<b>geoTile</b>()
+
+Constructs a layout for determining which 256x256 quadtree tiles to display in a rectangular viewport, based on a scale and translate. This layout can be used to create a simple slippy map, or render standard map tiles (e.g., MapBox, CloudMade) as a base layer behind a geographic projection.
+
+```js
+var tile = d3.geoTile();
+```
+
+<a href="#tile_size" name="tile_size">#</a> <i>tile</i>.<b>size</b>([<i>size</i>])
+
+If *size* is specified, sets this tile layout’s size to the specified two-element array of numbers [*width*, *height*] and returns this tile layout. If *size* is not specified, returns the current layout size.
+
+<a href="#tile_scale" name="tile_scale">#</a> <i>tile</i>.<b>scale</b>([<i>scale</i>])
+
+If *scale* is specified, sets this tile layout’s scale to the specified number *scale* and returns this tile layout. If *scale* is not specified, returns the current layout scale.
+
+<a href="#tile_translate" name="tile_translate">#</a> <i>tile</i>.<b>translate</b>([<i>translate</i>])
+
+If *translate* is specified, sets this tile layout’s translate to the specified two-element array of numbers [*x*, *y*] and returns this tile layout. If *translate* is not specified, returns the current layout translate.
+
+<a href="#tile_size" name="tile_size">#</a> <i>tile</i>()
+
+Computes the set of 256x256 quadtree tiles to display given the current layout [size](#tile_size), [scale](#tile_scale) and [translate](#tile_translate). Returns an array of arrays that specify tile addresses as `[x, y, z]` where `z` is the zoom level.
+
+For example, the address of a tile from OpenStreetMap can be computed as follows, where `d` is an entry in the returned array.
+
+```js
+"http://a.tile.openstreetmap.org/" + d[2] + "/" + d[0] + "/" + d[1] + ".png";
+```
+
+The returned array also has properties `scale` and `translate` that can be used to apply the correct transformation to a `<g>` element containing the tile images where tile images have unit width and height, and (x, y) coordinates corresponding to the tile address. For example usage, see [Raster & Vector 4.0](http://bl.ocks.org/curran/e857dbe6db49d4cac379855b0b6b58e9).

--- a/index.js
+++ b/index.js
@@ -25,3 +25,4 @@ export {default as geoTransverseMercator} from "./src/projection/transverseMerca
 export {default as geoRotation} from "./src/rotation";
 export {default as geoStream} from "./src/stream";
 export {default as geoTransform} from "./src/transform";
+export {default as geoTile} from "./src/tile";

--- a/src/tile.js
+++ b/src/tile.js
@@ -1,0 +1,55 @@
+import {range} from "d3-array";
+
+export default function() {
+  var size = [960, 500],
+      scale = 256,
+      translate = [size[0] / 2, size[1] / 2],
+      zoomDelta = 0;
+
+  function tile() {
+    var z = Math.max(Math.log(scale) / Math.LN2 - 8, 0),
+        z0 = Math.round(z + zoomDelta),
+        k = Math.pow(2, z - z0 + 8),
+        origin = [(translate[0] - scale / 2) / k, (translate[1] - scale / 2) / k],
+        tiles = [],
+        cols = range(Math.max(0, Math.floor(-origin[0])), Math.max(0, Math.ceil(size[0] / k - origin[0]))),
+        rows = range(Math.max(0, Math.floor(-origin[1])), Math.max(0, Math.ceil(size[1] / k - origin[1])));
+
+    rows.forEach(function(y) {
+      cols.forEach(function(x) {
+        tiles.push([x, y, z0]);
+      });
+    });
+
+    tiles.translate = origin;
+    tiles.scale = k;
+
+    return tiles;
+  }
+
+  tile.size = function(_) {
+    if (!arguments.length) return size;
+    size = _;
+    return tile;
+  };
+
+  tile.scale = function(_) {
+    if (!arguments.length) return scale;
+    scale = _;
+    return tile;
+  };
+
+  tile.translate = function(_) {
+    if (!arguments.length) return translate;
+    translate = _;
+    return tile;
+  };
+
+  tile.zoomDelta = function(_) {
+    if (!arguments.length) return zoomDelta;
+    zoomDelta = +_;
+    return tile;
+  };
+
+  return tile;
+}

--- a/test/tile-test.js
+++ b/test/tile-test.js
@@ -1,0 +1,25 @@
+var tape = require("tape"),
+    d3 = require("../");
+
+tape("tile", function(test) {
+  var width = 960,
+      height = 500,
+      tile = d3.geoTile()
+        .size([width, height])
+        .scale(4096)
+        .translate([1617, 747]),
+      tiles = tile();
+
+  test.deepEqual(tile.size(), [width, height]);
+  test.equal(tile.scale(), 4096);
+  test.deepEqual(tile.translate(), [1617, 747]);
+
+  test.equal(tiles.scale, 256);
+  test.equal(tiles.translate[0], -1.68359375);
+  test.equal(tiles.translate[1], -5.08203125);
+  test.equal(tiles.length, 15);
+  test.deepEqual(tiles[0], [ 1, 5, 4 ]);
+  test.deepEqual(tiles[1], [ 2, 5, 4 ]);
+  test.deepEqual(tiles[2], [ 3, 5, 4 ]);
+  test.end();
+});


### PR DESCRIPTION
This adds `d3.geoTile`.

Draws from existing code and documentation in [d3-plugins/geo/tile/](https://github.com/d3/d3-plugins/tree/master/geo/tile).

Values in the test were drawn from [Raster & Vector 4.0](http://bl.ocks.org/curran/e857dbe6db49d4cac379855b0b6b58e9)