### PR TITLE
Fixes link to TopoJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The projection of polygons and polylines must also deal with the topological dif
 
 D3’s approach affords great expressiveness: you can choose the right projection, and the right aspect, for your data. D3 supports a wide variety of common and [unusual map projections](https://github.com/d3/d3-geo-projection). For more, see Part 2 of [The Toolmaker’s Guide](https://vimeo.com/106198518#t=20m0s).
 
-D3 uses [GeoJSON](http://geojson.org/geojson-spec.html) to represent geographic features in JavaScript. (See also [TopoJSON](/mbostock/topojson), an extension of GeoJSON that is significantly more compact and encodes topology.) To convert shapefiles to GeoJSON, use ogr2ogr, part of the [GDAL package](http://www.gdal.org/). In addition to [map projections](#projections), D3 includes useful [spherical shape generators](#spherical-shapes) and [spherical math utilities](#spherical-math).
+D3 uses [GeoJSON](http://geojson.org/geojson-spec.html) to represent geographic features in JavaScript. (See also [TopoJSON](https://github.com/mbostock/topojson), an extension of GeoJSON that is significantly more compact and encodes topology.) To convert shapefiles to GeoJSON, use ogr2ogr, part of the [GDAL package](http://www.gdal.org/). In addition to [map projections](#projections), D3 includes useful [spherical shape generators](#spherical-shapes) and [spherical math utilities](#spherical-math).
 
 ## Installing
 


### PR DESCRIPTION
Relative links in README.md are interpreted as relative to the project, see https://github.com/blog/1395-relative-links-in-markup-files.

Thanks for your work on d3 :)