### PR TITLE
fix stereographicRaw.invert

### DIFF
--- a/src/projection/stereographic.js
+++ b/src/projection/stereographic.js
@@ -8,7 +8,7 @@ export function stereographicRaw(x, y) {
 }
 
 stereographicRaw.invert = azimuthalInvert(function(z) {
-  return 2 + atan(z);
+  return 2 * atan(z);
 });
 
 export default function() {


### PR DESCRIPTION
Simple test:
```
    var point = [ 360 * Math.random() - 180, 180 * Math.random() - 90 ],
        stereo = d3.geoStereographic();
    console.log(point + " = " + stereo.invert(stereo(point)));
```