### PR TITLE
Fixes conic projections where the apex is south

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ The conic conformal projection. The parallels default to [30°, 30°] resulting 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo/master/img/conicEqualArea.png" width="480" height="250">](http://bl.ocks.org/mbostock/3734308)
 
-The Albers’ equal-area conic projection. See also [*conic*.parallels](#conic_parallels).
+The Albers’ equal-area conic projection. The limit case where its standard parallels are symmetrical north and south of the Equator is undefined: use a cylindrical projection instead. See also [*conic*.parallels](#conic_parallels).
 
 <a href="#geoConicEquidistant" name="geoConicEquidistant">#</a> d3.<b>geoConicEquidistant</b>() [<>](https://github.com/d3/d3-geo/blob/master/src/projection/conicEquidistant.js "Source")
 
@@ -436,7 +436,7 @@ The transverse spherical Mercator projection. Defines a default [*projection*.cl
 
 <a href="#conic_parallels" name="conic_parallels">#</a> <i>conic</i>.<b>parallels</b>([<i>parallels</i>]) [<>](https://github.com/d3/d3-geo/blob/master/src/projection/conic.js#L10 "Source")
 
-…
+The [two standard parallels](https://en.wikipedia.org/wiki/Map_projection#Conic) that define the map layout in conic projections.
 
 <a href="#geoClipExtent" name="geoClipExtent">#</a> d3.<b>geoClipExtent</b>() [<>](https://github.com/d3/d3-geo/blob/master/src/clip/extent.js "Source")
 

--- a/README.md
+++ b/README.md
@@ -390,7 +390,7 @@ The conic conformal projection. The parallels default to [30°, 30°] resulting 
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo/master/img/conicEqualArea.png" width="480" height="250">](http://bl.ocks.org/mbostock/3734308)
 
-The Albers’ equal-area conic projection. The limit case where its standard parallels are symmetrical north and south of the Equator is undefined: use a cylindrical projection instead. See also [*conic*.parallels](#conic_parallels).
+The Albers’ equal-area conic projection. See also [*conic*.parallels](#conic_parallels).
 
 <a href="#geoConicEquidistant" name="geoConicEquidistant">#</a> d3.<b>geoConicEquidistant</b>() [<>](https://github.com/d3/d3-geo/blob/master/src/projection/conicEquidistant.js "Source")
 

--- a/src/projection/conicConformal.js
+++ b/src/projection/conicConformal.js
@@ -1,4 +1,4 @@
-import {atan, atan2, cos, epsilon, halfPi, log, pow, sign, sin, sqrt, tan} from "../math";
+import {abs, atan, atan2, cos, epsilon, halfPi, log, pow, sign, sin, sqrt, tan} from "../math";
 import {conicProjection} from "./conic";
 import {mercatorRaw} from "./mercator";
 
@@ -22,7 +22,7 @@ export function conicConformalRaw(y0, y1) {
 
   project.invert = function(x, y) {
     var fy = f - y, r = sign(n) * sqrt(x * x + fy * fy);
-    return [atan2(x, fy) / n, 2 * atan(pow(f / r, 1 / n)) - halfPi];
+    return [atan2(x, abs(fy)) / n * sign(fy), 2 * atan(pow(f / r, 1 / n)) - halfPi];
   };
 
   return project;

--- a/src/projection/conicEqualArea.js
+++ b/src/projection/conicEqualArea.js
@@ -1,11 +1,18 @@
-import {asin, atan2, cos, sin, sqrt} from "../math";
+import {abs, asin, atan2, cos, sign, sin, sqrt} from "../math";
 import {conicProjection} from "./conic";
 
 export function conicEqualAreaRaw(y0, y1) {
   var sy0 = sin(y0),
       n = (sy0 + sin(y1)) / 2,
-      c = 1 + sy0 * (2 * n - sy0),
-      r0 = sqrt(c) / n;
+      c = 1 + sy0 * (2 * n - sy0);
+
+  // gracefully handle the limit case where the two standard parallels
+  // are symetrical with the Equator
+  if (abs(n) < 1e-10) {
+      n = (n < 0 ? -1 : 1) * 1e-10;
+  }
+
+  var r0 = sqrt(c) / n;
 
   function project(x, y) {
     var r = sqrt(c - 2 * n * sin(y)) / n;
@@ -14,7 +21,7 @@ export function conicEqualAreaRaw(y0, y1) {
 
   project.invert = function(x, y) {
     var r0y = r0 - y;
-    return [atan2(x, r0y) / n, asin((c - (x * x + r0y * r0y) * n * n) / (2 * n))];
+    return [atan2(x, abs(r0y)) / n * sign(r0y), asin((c - (x * x + r0y * r0y) * n * n) / (2 * n))];
   };
 
   return project;

--- a/src/projection/conicEquidistant.js
+++ b/src/projection/conicEquidistant.js
@@ -16,7 +16,7 @@ export function conicEquidistantRaw(y0, y1) {
 
   project.invert = function(x, y) {
     var gy = g - y;
-    return [atan2(x, gy) / n, g - sign(n) * sqrt(x * x + gy * gy)];
+    return [atan2(x, abs(gy)) / n * sign(gy), g - sign(n) * sqrt(x * x + gy * gy)];
   };
 
   return project;

--- a/test/projection/invert-test.js
+++ b/test/projection/invert-test.js
@@ -1,0 +1,40 @@
+var tape = require("tape"),
+    d3 = require("../../");
+
+require("./projectionEqual");
+
+var pi = Math.PI;
+
+tape("projection.invert(projection(point)) returns the point", function(test) {
+  [
+    d3.geoAlbers(),
+    /* d3.geoAlbersUsa(), */
+    d3.geoAzimuthalEqualArea(),
+    d3.geoAzimuthalEquidistant(),
+    d3.geoConicConformal(),
+    d3.geoConicConformal().parallels([20,30]),
+    d3.geoConicConformal().parallels([30,30]),
+    d3.geoConicConformal().parallels([-35,-50]),
+    d3.geoConicEqualArea(),
+    d3.geoConicEqualArea().parallels([20,30]),
+    d3.geoConicEqualArea().parallels([-30,30]),
+    d3.geoConicEqualArea().parallels([-35,-50]), // https://github.com/d3/d3/issues/2707
+    d3.geoConicEquidistant(),
+    d3.geoConicEquidistant().parallels([20,30]),
+    d3.geoConicEquidistant().parallels([30,30]),
+    d3.geoConicEquidistant().parallels([-35,-50]),
+    d3.geoEquirectangular(),
+    d3.geoGnomonic(),
+    d3.geoMercator(),
+    d3.geoOrthographic(),
+    d3.geoStereographic(),
+    d3.geoTransverseMercator(),
+  ]
+  .forEach(function(projection) {
+     [ [0, 0], [30, 24], [ -10, 42 ] ]
+     .forEach(function(point) {
+         test.projectionEqual(projection, point, projection(point));
+     });
+  });
+  test.end();
+});

--- a/test/projection/invert-test.js
+++ b/test/projection/invert-test.js
@@ -3,8 +3,6 @@ var tape = require("tape"),
 
 require("./projectionEqual");
 
-var pi = Math.PI;
-
 tape("projection.invert(projection(point)) returns the point", function(test) {
   [
     d3.geoAlbers(),

--- a/test/projection/invert-test.js
+++ b/test/projection/invert-test.js
@@ -29,7 +29,7 @@ tape("projection.invert(projection(point)) returns the point", function(test) {
     d3.geoTransverseMercator(),
   ]
   .forEach(function(projection) {
-     [ [0, 0], [30, 24], [ -10, 42 ] ]
+     [ [0, 0], [30.3, 24.1], [ -10, 42 ], [ -2, -5 ] ]
      .forEach(function(point) {
          test.projectionEqual(projection, point, projection(point));
      });


### PR DESCRIPTION
Fixes conic projections where the apex is south, or where the apex is infinite (in other words, where the cone is a cylinder).

Fixes https://github.com/d3/d3/issues/2707

Visual test case at http://bl.ocks.org/Fil/bdf4e2b18aff57b7c7b3411e3609e546

Add systematic testing of inverse projections.