### PR TITLE
Instability of angle computation in geoCentroid (solves #81) 

### DIFF
--- a/src/centroid.js
+++ b/src/centroid.js
@@ -1,4 +1,4 @@
-import {acos, asin, atan2, cos, degrees, epsilon, epsilon2, radians, sin, sqrt} from "./math";
+import {asin, atan2, cos, degrees, epsilon, epsilon2, radians, sin, sqrt} from "./math";
 import noop from "./noop";
 import stream from "./stream";
 
@@ -103,7 +103,7 @@ function centroidRingPoint(lambda, phi) {
       cz = x0 * y - y0 * x,
       m = sqrt(cx * cx + cy * cy + cz * cz),
       u = x0 * x + y0 * y + z0 * z,
-      v = m && -acos(u) / m, // area weight
+      v = m && -asin(m) / m, // area weight
       w = atan2(m, u); // line weight
   X2 += v * cx;
   Y2 += v * cy;

--- a/test/centroid-test.js
+++ b/test/centroid-test.js
@@ -89,10 +89,10 @@ tape("the centroid of a set of polygons is the (spherical) average of its surfac
   test.inDelta(d3.geoCentroid({
     type: "MultiPolygon",
     coordinates: [
-      circle.radius(45).center([0, 0])().coordinates,
-      circle.radius(60).center([180, 0])().coordinates
+      circle.radius(45).center([90, 0])().coordinates,
+      circle.radius(60).center([-90, 0])().coordinates
     ]
-  }), [180, 0], 1e-6);
+  }), [-90, 0], 1e-6);
   test.end();
 });
 


### PR DESCRIPTION
The way we computed the angle with `acos(sqrt(A.B))` was sometimes grossly inaccurate, when vectors A and B are very close to each other. Using `acos(norm(AxB))` doesn't have that numerical instability around angle=0.

Needs a rotation in a test that was expecting a result at lon=180 (the new method tends to yield -180).

Solves #81.