### PR TITLE
Clamp Mercator clip extent.

### DIFF
--- a/src/projection/mercator.js
+++ b/src/projection/mercator.js
@@ -22,22 +22,22 @@ export function mercatorProjection(project) {
       clipAuto;
 
   m.scale = function(_) {
-    return arguments.length ? (scale(_), clipAuto && m.clipExtent(null), m) : scale();
+    return arguments.length ? (scale(_), clipAuto ? m.clipExtent(null) : m) : scale();
   };
 
   m.translate = function(_) {
-    return arguments.length ? (translate(_), clipAuto && m.clipExtent(null), m) : translate();
+    return arguments.length ? (translate(_), clipAuto ? m.clipExtent(null) : m) : translate();
   };
 
   m.clipExtent = function(_) {
     if (!arguments.length) return clipAuto ? null : clipExtent();
-    if (clipAuto = _ == null) {
-      var k = pi * scale(),
-          t = translate();
-      _ = [[t[0] - k, t[1] - k], [t[0] + k, t[1] + k]];
-    }
-    clipExtent(_);
-    return m;
+    var k = pi * scale(),
+        t = translate(),
+        x0 = t[0] - k,
+        x1 = t[0] + k;
+    return clipExtent(clipAuto = _ == null
+        ? [[x0, t[1] - k], [x1, t[1] + k]]
+        : [[Math.max(x0, +_[0][0]), _[0][1]], [Math.min(x1, +_[1][0]), _[1][1]]]);
   };
 
   return m.clipExtent(null);

--- a/src/projection/mercator.js
+++ b/src/projection/mercator.js
@@ -30,10 +30,7 @@ export function mercatorProjection(project) {
   };
 
   m.clipExtent = function(_) {
-    if (!arguments.length) return x0 == null ? null : [[x0, y0], [x1, y1]];
-    if (_ == null) x0 = y0 = x1 = y1 = null;
-    else x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1];
-    return reclip();
+    return arguments.length ? ((_ == null ? x0 = y0 = x1 = y1 = null : (x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1])), reclip()) : x0 == null ? null : [[x0, y0], [x1, y1]];
   };
 
   function reclip() {

--- a/src/projection/mercator.js
+++ b/src/projection/mercator.js
@@ -19,26 +19,30 @@ export function mercatorProjection(project) {
       scale = m.scale,
       translate = m.translate,
       clipExtent = m.clipExtent,
-      clipAuto;
+      x0 = null, y0, x1, y1; // clip extent
 
   m.scale = function(_) {
-    return arguments.length ? (scale(_), clipAuto ? m.clipExtent(null) : m) : scale();
+    return arguments.length ? (scale(_), reclip()) : scale();
   };
 
   m.translate = function(_) {
-    return arguments.length ? (translate(_), clipAuto ? m.clipExtent(null) : m) : translate();
+    return arguments.length ? (translate(_), reclip()) : translate();
   };
 
   m.clipExtent = function(_) {
-    if (!arguments.length) return clipAuto ? null : clipExtent();
-    var k = pi * scale(),
-        t = translate(),
-        x0 = t[0] - k,
-        x1 = t[0] + k;
-    return clipExtent(clipAuto = _ == null
-        ? [[x0, t[1] - k], [x1, t[1] + k]]
-        : [[Math.max(x0, +_[0][0]), _[0][1]], [Math.min(x1, +_[1][0]), _[1][1]]]);
+    if (!arguments.length) return x0 == null ? null : [[x0, y0], [x1, y1]];
+    if (_ == null) x0 = y0 = x1 = y1 = null;
+    else x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1];
+    return reclip();
   };
 
-  return m.clipExtent(null);
+  function reclip() {
+    var k = pi * scale(),
+        t = translate();
+    return clipExtent(x0 == null
+        ? [[t[0] - k, t[1] - k], [t[0] + k, t[1] + k]]
+        : [[Math.max(t[0] - k, x0), y0], [Math.min(t[0] + k, x1), y1]]);
+  }
+
+  return reclip();
 }

--- a/test/projection/mercator-test.js
+++ b/test/projection/mercator-test.js
@@ -1,0 +1,32 @@
+var tape = require("tape"),
+    d3 = require("../../");
+
+require("../pathEqual");
+
+tape("mercator.clipExtent(null) sets the default automatic clip extent", function(test) {
+  var mercator = d3.geoMercator().translate([0, 0]).scale(1).clipExtent(null).precision(0);
+  test.pathEqual(d3.geoPath(mercator)({type: "Sphere"}), "M3.141593,-3.141593L3.141593,0L3.141593,3.141593L3.141593,3.141593L-3.141593,3.141593L-3.141593,3.141593L-3.141593,0L-3.141593,-3.141593L-3.141593,-3.141593L3.141593,-3.141593Z");
+  test.equal(mercator.clipExtent(), null);
+  test.end();
+});
+
+tape("mercator.clipExtent(extent) intersects the specified clip extent with the automatic clip extent", function(test) {
+  var mercator = d3.geoMercator().translate([0, 0]).scale(1).clipExtent([[-10, -10], [10, 10]]).precision(0);
+  test.pathEqual(d3.geoPath(mercator)({type: "Sphere"}), "M3.141593,-10L3.141593,0L3.141593,10L3.141593,10L-3.141593,10L-3.141593,10L-3.141593,0L-3.141593,-10L-3.141593,-10L3.141593,-10Z");
+  test.deepEqual(mercator.clipExtent(), [[-10, -10], [10, 10]]);
+  test.end();
+});
+
+tape("mercator.clipExtent(extent).scale(scale) updates the intersected clip extent", function(test) {
+  var mercator = d3.geoMercator().translate([0, 0]).clipExtent([[-10, -10], [10, 10]]).scale(1).precision(0);
+  test.pathEqual(d3.geoPath(mercator)({type: "Sphere"}), "M3.141593,-10L3.141593,0L3.141593,10L3.141593,10L-3.141593,10L-3.141593,10L-3.141593,0L-3.141593,-10L-3.141593,-10L3.141593,-10Z");
+  test.deepEqual(mercator.clipExtent(), [[-10, -10], [10, 10]]);
+  test.end();
+});
+
+tape("mercator.clipExtent(extent).translate(translate) updates the intersected clip extent", function(test) {
+  var mercator = d3.geoMercator().scale(1).clipExtent([[-10, -10], [10, 10]]).translate([0, 0]).precision(0);
+  test.pathEqual(d3.geoPath(mercator)({type: "Sphere"}), "M3.141593,-10L3.141593,0L3.141593,10L3.141593,10L-3.141593,10L-3.141593,10L-3.141593,0L-3.141593,-10L-3.141593,-10L3.141593,-10Z");
+  test.deepEqual(mercator.clipExtent(), [[-10, -10], [10, 10]]);
+  test.end();
+});


### PR DESCRIPTION
The Mercator projection is only defined on *x* in [*tx* - *k* × π, *tx* + *k* × π] where *tx* is the *x*-translate ([*projection*.translate](https://github.com/d3/d3-geo/blob/master/README.md#projection_translate)) and *k* is the scale ([*projection*.scale](https://github.com/d3/d3-geo/blob/master/README.md#projection_translate)). Thus setting a manual clip extent outside these bounds can break the projection; see https://github.com/d3/d3-geo/issues/55#issuecomment-283703047.

If a clip extent is specified, this clip extent is now intersected with the defined extent of the Mercator projection on *x*. Note that it is *not* clamped on *y*, as the Mercator projection is defined to the poles at infinity.