### PR TITLE
Moving rotate outside of the clipAngle|clipAntimeridian code?

### DIFF
--- a/src/clip/index.js
+++ b/src/clip/index.js
@@ -5,9 +5,8 @@ import polygonContains from "../polygonContains";
 import {merge} from "d3-array";
 
 export default function(pointVisible, clipLine, interpolate, start) {
-  return function(rotate, sink) {
+  return function(sink) {
     var line = clipLine(sink),
-        rotatedStart = rotate.invert(start[0], start[1]),
         ringBuffer = clipBuffer(),
         ringSink = clipLine(ringBuffer),
         polygonStarted = false,
@@ -31,7 +30,7 @@ export default function(pointVisible, clipLine, interpolate, start) {
         clip.lineStart = lineStart;
         clip.lineEnd = lineEnd;
         segments = merge(segments);
-        var startInside = polygonContains(polygon, rotatedStart);
+        var startInside = polygonContains(polygon, start);
         if (segments.length) {
           if (!polygonStarted) sink.polygonStart(), polygonStarted = true;
           clipPolygon(segments, compareIntersection, startInside, interpolate, sink);
@@ -54,13 +53,11 @@ export default function(pointVisible, clipLine, interpolate, start) {
     };
 
     function point(lambda, phi) {
-      var point = rotate(lambda, phi);
-      if (pointVisible(lambda = point[0], phi = point[1])) sink.point(lambda, phi);
+      if (pointVisible(lambda, phi)) sink.point(lambda, phi);
     }
 
     function pointLine(lambda, phi) {
-      var point = rotate(lambda, phi);
-      line.point(point[0], point[1]);
+      line.point(lambda, phi);
     }
 
     function lineStart() {
@@ -75,8 +72,7 @@ export default function(pointVisible, clipLine, interpolate, start) {
 
     function pointRing(lambda, phi) {
       ring.push([lambda, phi]);
-      var point = rotate(lambda, phi);
-      ringSink.point(point[0], point[1]);
+      ringSink.point(lambda, phi);
     }
 
     function ringStart() {

--- a/src/projection/index.js
+++ b/src/projection/index.js
@@ -45,8 +45,17 @@ export function projectionMutator(projectAt) {
     return x = project(x, y), [x[0] * k + dx, dy - x[1] * k];
   }
 
+  function rotateTransform(rotate) {
+    return transformer({
+        point: function(x,y) {
+          var r = rotate(x,y);
+          return this.stream.point(r[0],r[1]);
+        }
+    });
+  }
+
   projection.stream = function(stream) {
-    return cache && cacheStream === stream ? cache : cache = transformRadians(preclip(rotate, projectResample(postclip(cacheStream = stream))));
+    return cache && cacheStream === stream ? cache : cache = transformRadians(rotateTransform(rotate)(preclip(projectResample(postclip(cacheStream = stream)))));
   };
 
   projection.clipAngle = function(_) {

--- a/test/rotation-test.js
+++ b/test/rotation-test.js
@@ -30,4 +30,30 @@ tape("a rotation of [-45°, -45°] inverse rotation of longitude and latitude", 
   test.inDelta(rotation[1], 0, 1e-6);
   test.end();
 });
-      
+
+tape("a rtation of a degenerate polygon should not break",
+function(test) {
+  var feature = {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [125.67351590459046, -14.17673705310531],
+        [125.67351590459046, -14.173276873687367],
+        [125.67351590459046, -14.173276873687367],
+        [125.67351590459046, -14.169816694269425],
+        [125.67351590459046, -14.17673705310531]
+      ]
+    ]
+  };
+
+  var projection = d3.geoMercator()
+    .rotate([-134.300, 25.776])
+    .scale(750)
+    .translate([0, 0]),
+    path = d3.geoPath(projection),
+    d = path(feature).replace(/\.\d+/g,'');
+
+  test.equal(d, "M-111,-149L-111,-149L-111,-149L-111,-149Z");
+  test.end();
+
+});


### PR DESCRIPTION
The pre-clip code is mixed with rotate, which seems unnecessarily complex. 

It seems to me that untangling this allows for easier experimentation with preclipping (https://github.com/d3/d3-geo/issues/46), and is a small step towards the "graphics pipeline" issue https://github.com/d3/d3-geo/issues/78.

I've run all tests in d3-geo and d3-geo-projection as well as manually checked for clipAngle() with values higher and lower than 90, as this was the only case affecting `start` vs `projectedStart`. Everything seems to work — have I missed something? Also, `rotateTransform` is probably poorly named.