### PR TITLE
[geoPath] Refine PathString  result() return type.

### DIFF
--- a/src/path/string.js
+++ b/src/path/string.js
@@ -42,6 +42,8 @@ PathString.prototype = {
       var result = this._string.join("");
       this._string = [];
       return result;
+    } else {
+      return null;
     }
   }
 };


### PR DESCRIPTION
For the scenario where `geoPath(...)` is used to obtain a path string (e.g. rendering to `<svg>` using `geoPath(...)` with `Selection.attr('d',...)`) there is a subtle difference to similar path string generators in **d3-shape**:

* **d3-geo** [PathString.result()](https://github.com/d3/d3-geo/blob/master/src/path/string.js#L40) returns either a `string` or in edge cases is `void`, i.e. the return value is `undefined`.
* **d3-shape** Path string generator return types, such as the one for `Arc(...)`  [at Line 217 here](https://github.com/d3/d3-shape/blob/master/src/arc.js#L217) return either a `string` or fall back to `null`

This PR suggests harmonizing `PathString` to the **d3-shape** behavior for the fall back.