### PR TITLE
corrected error in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,6 @@ The equirectangular (plate carrée) projection.
 
 [<img src="https://raw.githubusercontent.com/d3/d3-geo/master/img/mercator.png" width="480" height="250">](https://bl.ocks.org/mbostock/3757132)
 
-The spherical Mercator projection. Defines a default [*projection*.clipExtent](#projection_clipExtent) such that the world is projected to a square, clipped to approximately ±85° latitude.
-
 <a href="#geoTransverseMercator" name="geoTransverseMercator">#</a> d3.<b>geoTransverseMercator</b>() [<>](https://github.com/d3/d3-geo/blob/master/src/projection/transverseMercator.js "Source")
 <br><a href="#geoTransverseMercatorRaw" name="geoTransverseMercatorRaw">#</a> d3.<b>geoTransverseMercatorRaw</b>
 


### PR DESCRIPTION
From what I can tell the spherical Mercator projection no longer defines a default clipping extent.

I have removed the note mentioning this from the documentation.