### PR TITLE
Error with exports in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export {default as geoGnomonic, gnomonicRaw as geoGnomonicRaw} from "./src/proje
 export {default as geoIdentity} from "./src/projection/identity";
 export {default as geoProjection, projectionMutator as geoProjectionMutator} from "./src/projection/index";
 export {default as geoMercator, mercatorRaw as geoMercatorRaw} from "./src/projection/mercator";
-export {default as geoNaturalEarth1, naturalEarth1Raw as geoNaturalEarthRaw1} from "./src/projection/naturalEarth1";
+export {default as geoNaturalEarth1, naturalEarth1Raw as geoNaturalEarth1Raw} from "./src/projection/naturalEarth1";
 export {default as geoOrthographic, orthographicRaw as geoOrthographicRaw} from "./src/projection/orthographic";
 export {default as geoStereographic, stereographicRaw as geoStereographicRaw} from "./src/projection/stereographic";
 export {default as geoTransverseMercator, transverseMercatorRaw as geoTransverseMercatorRaw} from "./src/projection/transverseMercator";

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export {default as geoGnomonic, gnomonicRaw as geoGnomonicRaw} from "./src/proje
 export {default as geoIdentity} from "./src/projection/identity";
 export {default as geoProjection, projectionMutator as geoProjectionMutator} from "./src/projection/index";
 export {default as geoMercator, mercatorRaw as geoMercatorRaw} from "./src/projection/mercator";
-export {default as geoNaturalEarth1, naturalEarth1Raw as geoNaturalEarth1Raw} from "./src/projection/naturalEarth1";
+export {default as geoNaturalEarth1, naturalEarth1Raw as geoNaturalEarthRaw1} from "./src/projection/naturalEarth1";
 export {default as geoOrthographic, orthographicRaw as geoOrthographicRaw} from "./src/projection/orthographic";
 export {default as geoStereographic, stereographicRaw as geoStereographicRaw} from "./src/projection/stereographic";
 export {default as geoTransverseMercator, transverseMercatorRaw as geoTransverseMercatorRaw} from "./src/projection/transverseMercator";

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ export {default as geoGnomonic, gnomonicRaw as geoGnomonicRaw} from "./src/proje
 export {default as geoIdentity} from "./src/projection/identity";
 export {default as geoProjection, projectionMutator as geoProjectionMutator} from "./src/projection/index";
 export {default as geoMercator, mercatorRaw as geoMercatorRaw} from "./src/projection/mercator";
-export {default as geoNaturalEarth1, naturalEarth1Raw as geogeoNaturalEarth1Raw} from "./src/projection/naturalEarth1";
+export {default as geoNaturalEarth1, naturalEarth1Raw as geoNaturalEarth1Raw} from "./src/projection/naturalEarth1";
 export {default as geoOrthographic, orthographicRaw as geoOrthographicRaw} from "./src/projection/orthographic";
 export {default as geoStereographic, stereographicRaw as geoStereographicRaw} from "./src/projection/stereographic";
 export {default as geoTransverseMercator, transverseMercatorRaw as geoTransverseMercatorRaw} from "./src/projection/transverseMercator";


### PR DESCRIPTION
I encountered problems preparing a custom bundle of d3 using the latest versions of d3-geo and d3-geo-projection and saw this item in the `index.js` file.

I guess the "geogeo" prefix is a typo and should be corrected to simply "geo" ? Furthermore I also changed `geoNaturalEarth1Raw` to `geoNaturalEarthRaw1` as this is how that projection is imported in d3-geo-projection [index.js](https://github.com/d3/d3-geo-projection/blob/fac29d0f5cca7d86830591264a277104d63f51ca/index.js#L60) file (but maybe it should not be fixed here but in d3-geo-projection instead ?).