### PR TITLE
fix contains(polygon,pole) when the polygon goes through the pole (#105)

### DIFF
--- a/src/polygonContains.js
+++ b/src/polygonContains.js
@@ -46,6 +46,8 @@ export default function(polygon, point) {
         var intersection = cartesianCross(normal, arc);
         cartesianNormalizeInPlace(intersection);
         var phiArc = (antimeridian ^ delta >= 0 ? -1 : 1) * asin(intersection[2]);
+        var pole = sin(phi);
+        if (pole == -1 || pole == 1) phi += pole * epsilon;
         if (phi > phiArc || phi === phiArc && (arc[0] || arc[1])) {
           winding += antimeridian ^ delta >= 0 ? 1 : -1;
         }

--- a/test/polygonContains-test.js
+++ b/test/polygonContains-test.js
@@ -34,6 +34,7 @@ rollup.rollup({input: "src/polygonContains.js"})
     var polygon = [[[-60, -80], [60, -80], [180, -80], [-60, -80]]];
     test.equal(polygonContains(polygon, [0, 0]), 0);
     test.equal(polygonContains(polygon, [0, -85]), 1);
+    test.equal(polygonContains(polygon, [0, -90]), 1);
     test.end();
   });
 
@@ -41,6 +42,28 @@ rollup.rollup({input: "src/polygonContains.js"})
     var polygon = [[[60, 80], [-60, 80], [-180, 80], [60, 80]]];
     test.equal(polygonContains(polygon, [0, 0]), 0);
     test.equal(polygonContains(polygon, [0, 85]), 1);
+    test.equal(polygonContains(polygon, [0, 90]), 1);
+    test.equal(polygonContains(polygon, [-100, 90]), 1);
+    test.equal(polygonContains(polygon, [0, -90]), 0);
+    test.end();
+  });
+
+  tape("geoPolygonContains(touchingPole, Pole) returns true (issue #105)", function(test) {
+    var polygon = [[[0, -30], [120, -30], [0, -90], [0, -30]]];
+    test.equal(polygonContains(polygon, [0, -90]), 0);
+    test.equal(polygonContains(polygon, [-60, -90]), 0);
+    test.equal(polygonContains(polygon, [60, -90]), 0);
+    polygon = [[[0, 30], [-120, 30], [0, 90], [0, 30]]];
+    test.equal(polygonContains(polygon, [0, 90]), 0);
+    test.equal(polygonContains(polygon, [-60, 90]), 0);
+    test.equal(polygonContains(polygon, [60, 90]), 0);
+    test.end();
+  });
+
+  tape("geoPolygonContains(southHemispherePoly) returns the expected value", function(test) {
+    var polygon = [[[0, 0], [10, -40], [-10, -40], [0, 0]]];
+    test.equal(polygonContains(polygon, [0,-40.2]), 1);
+    test.equal(polygonContains(polygon, [0,-40.5]), 0);
     test.end();
   });
 


### PR DESCRIPTION
Note that the choice to return 0 in this situation is arbitrary -- but if we set it to 1, cutting fails. A different approach based on 3D (cartesian) maths might help.

(copy of 094034c3204d57e371422d12958d0ce27f94a420 which went to master instead of this feature branch)