### PR TITLE
d3.geoContains should wrap longitudes

### DIFF
--- a/src/polygonContains.js
+++ b/src/polygonContains.js
@@ -1,11 +1,18 @@
 import adder from "./adder";
 import {cartesian, cartesianCross, cartesianNormalizeInPlace} from "./cartesian";
-import {asin, atan2, cos, epsilon, halfPi, pi, quarterPi, sin, tau} from "./math";
+import {abs, asin, atan2, cos, epsilon, halfPi, pi, quarterPi, sign, sin, tau} from "./math";
 
 var sum = adder();
 
+function longitude(point) {
+  if (abs(point[0]) <= pi)
+    return point[0];
+  else
+    return sign(point[0]) * ((abs(point[0]) + pi) % tau - pi);
+}
+
 export default function(polygon, point) {
-  var lambda = point[0],
+  var lambda = longitude(point),
       phi = point[1],
       sinPhi = sin(phi),
       normal = [sin(lambda), -cos(lambda), 0],
@@ -22,14 +29,14 @@ export default function(polygon, point) {
     var ring,
         m,
         point0 = ring[m - 1],
-        lambda0 = point0[0],
+        lambda0 = longitude(point0),
         phi0 = point0[1] / 2 + quarterPi,
         sinPhi0 = sin(phi0),
         cosPhi0 = cos(phi0);
 
     for (var j = 0; j < m; ++j, lambda0 = lambda1, sinPhi0 = sinPhi1, cosPhi0 = cosPhi1, point0 = point1) {
       var point1 = ring[j],
-          lambda1 = point1[0],
+          lambda1 = longitude(point1),
           phi1 = point1[1] / 2 + quarterPi,
           sinPhi1 = sin(phi1),
           cosPhi1 = cos(phi1),

--- a/test/polygonContains-test.js
+++ b/test/polygonContains-test.js
@@ -30,6 +30,14 @@ rollup.rollup({input: "src/polygonContains.js"})
     test.end();
   });
 
+  tape("geoPolygonContains wraps longitudes", function(test) {
+    var polygon = d3_geo.geoCircle().center([300, 0])().coordinates;
+    test.equal(polygonContains(polygon, [300, 0]), 1);
+    test.equal(polygonContains(polygon, [-60, 0]), 1);
+    test.equal(polygonContains(polygon, [-420, 0]), 1);
+    test.end();
+  });
+
   tape("geoPolygonContains(southPole, point) returns the expected value", function(test) {
     var polygon = [[[-60, -80], [60, -80], [180, -80], [-60, -80]]];
     test.equal(polygonContains(polygon, [0, 0]), 0);


### PR DESCRIPTION
(fixes #164 ; see https://observablehq.com/d/7348fad01d32a192)