### PR TITLE
Identity projection simpler

### DIFF
--- a/src/projection/identity.js
+++ b/src/projection/identity.js
@@ -24,10 +24,10 @@ export default function() {
   }
 
   function projection (p) {
-    return [p[0] * k + tx, p[1] * k + ty];
+    return [p[0] * k * sx + tx, p[1] * k * sy + ty];
   }
   projection.invert = function(p) {
-    return [(p[0] - tx) / k, (p[1] - ty) / k];
+    return [(p[0] - tx) / k * sx, (p[1] - ty) / k * sy];
   };
   projection.stream = function(stream) {
     return cache && cacheStream === stream ? cache : cache = transform(postclip(cacheStream = stream));

--- a/src/projection/identity.js
+++ b/src/projection/identity.js
@@ -16,17 +16,16 @@ export default function() {
       x0 = null, y0, x1, y1, // clip extent
       postclip = identity,
       cache,
-      cacheStream,
-      projection;
+      cacheStream;
 
   function reset() {
     cache = cacheStream = null;
     return projection;
   }
 
-  projection = function(p) {
+  function projection (p) {
     return [p[0] * k + tx, p[1] * k + ty];
-  };
+  }
   projection.invert = function(p) {
     return [(p[0] - tx) / k, (p[1] - ty) / k];
   };

--- a/src/projection/identity.js
+++ b/src/projection/identity.js
@@ -24,39 +24,45 @@ export default function() {
     return projection;
   }
 
-  return projection = {
-    stream: function(stream) {
-      return cache && cacheStream === stream ? cache : cache = transform(postclip(cacheStream = stream));
-    },
-    postclip: function(_) {
-      return arguments.length ? (postclip = _, x0 = y0 = x1 = y1 = null, reset()) : postclip;
-    },
-    clipExtent: function(_) {
-      return arguments.length ? (postclip = _ == null ? (x0 = y0 = x1 = y1 = null, identity) : clipRectangle(x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1]), reset()) : x0 == null ? null : [[x0, y0], [x1, y1]];
-    },
-    scale: function(_) {
-      return arguments.length ? (transform = scaleTranslate((k = +_) * sx, k * sy, tx, ty), reset()) : k;
-    },
-    translate: function(_) {
-      return arguments.length ? (transform = scaleTranslate(k * sx, k * sy, tx = +_[0], ty = +_[1]), reset()) : [tx, ty];
-    },
-    reflectX: function(_) {
-      return arguments.length ? (transform = scaleTranslate(k * (sx = _ ? -1 : 1), k * sy, tx, ty), reset()) : sx < 0;
-    },
-    reflectY: function(_) {
-      return arguments.length ? (transform = scaleTranslate(k * sx, k * (sy = _ ? -1 : 1), tx, ty), reset()) : sy < 0;
-    },
-    fitExtent: function(extent, object) {
-      return fitExtent(projection, extent, object);
-    },
-    fitSize: function(size, object) {
-      return fitSize(projection, size, object);
-    },
-    fitWidth: function(width, object) {
-      return fitWidth(projection, width, object);
-    },
-    fitHeight: function(height, object) {
-      return fitHeight(projection, height, object);
-    }
+  projection = function(p) {
+    return [p[0] * k + tx, p[1] * k + ty];
   };
+  projection.invert = function(p) {
+    return [(p[0] - tx) / k, (p[1] - ty) / k];
+  };
+  projection.stream = function(stream) {
+    return cache && cacheStream === stream ? cache : cache = transform(postclip(cacheStream = stream));
+  };
+  projection.postclip = function(_) {
+    return arguments.length ? (postclip = _, x0 = y0 = x1 = y1 = null, reset()) : postclip;
+  };
+  projection.clipExtent = function(_) {
+    return arguments.length ? (postclip = _ == null ? (x0 = y0 = x1 = y1 = null, identity) : clipRectangle(x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1]), reset()) : x0 == null ? null : [[x0, y0], [x1, y1]];
+  };
+  projection.scale = function(_) {
+    return arguments.length ? (transform = scaleTranslate((k = +_) * sx, k * sy, tx, ty), reset()) : k;
+  };
+  projection.translate = function(_) {
+    return arguments.length ? (transform = scaleTranslate(k * sx, k * sy, tx = +_[0], ty = +_[1]), reset()) : [tx, ty];
+  }
+  projection.reflectX = function(_) {
+    return arguments.length ? (transform = scaleTranslate(k * (sx = _ ? -1 : 1), k * sy, tx, ty), reset()) : sx < 0;
+  };
+  projection.reflectY = function(_) {
+    return arguments.length ? (transform = scaleTranslate(k * sx, k * (sy = _ ? -1 : 1), tx, ty), reset()) : sy < 0;
+  };
+  projection.fitExtent = function(extent, object) {
+    return fitExtent(projection, extent, object);
+  };
+  projection.fitSize = function(size, object) {
+    return fitSize(projection, size, object);
+  };
+  projection.fitWidth = function(width, object) {
+    return fitWidth(projection, width, object);
+  };
+  projection.fitHeight = function(height, object) {
+    return fitHeight(projection, height, object);
+  };
+
+  return projection;
 }

--- a/src/projection/identity.js
+++ b/src/projection/identity.js
@@ -3,31 +3,32 @@ import identity from "../identity.js";
 import {transformer} from "../transform.js";
 import {fitExtent, fitSize, fitWidth, fitHeight} from "./fit.js";
 
-function scaleTranslate(kx, ky, tx, ty) {
-  return kx === 1 && ky === 1 && tx === 0 && ty === 0 ? identity : transformer({
-    point: function(x, y) {
-      this.stream.point(x * kx + tx, y * ky + ty);
-    }
-  });
-}
-
 export default function() {
-  var k = 1, tx = 0, ty = 0, sx = 1, sy = 1, transform = identity, // scale, translate and reflect
+  var k = 1, tx = 0, ty = 0, sx = 1, sy = 1, // scale, translate and reflect
       x0 = null, y0, x1, y1, // clip extent
+      kx = 1, ky = 1,
+      transform = transformer({
+        point: function(x, y) {
+          var p = projection([x, y])
+          this.stream.point(p[0], p[1]);
+        }
+      }),
       postclip = identity,
       cache,
       cacheStream;
 
   function reset() {
+    kx = k * sx;
+    ky = k * sy;
     cache = cacheStream = null;
     return projection;
   }
 
   function projection (p) {
-    return [p[0] * k * sx + tx, p[1] * k * sy + ty];
+    return [p[0] * kx + tx, p[1] * ky + ty];
   }
   projection.invert = function(p) {
-    return [(p[0] - tx) / k * sx, (p[1] - ty) / k * sy];
+    return [(p[0] - tx) / kx, (p[1] - ty) / ky];
   };
   projection.stream = function(stream) {
     return cache && cacheStream === stream ? cache : cache = transform(postclip(cacheStream = stream));
@@ -39,16 +40,16 @@ export default function() {
     return arguments.length ? (postclip = _ == null ? (x0 = y0 = x1 = y1 = null, identity) : clipRectangle(x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1]), reset()) : x0 == null ? null : [[x0, y0], [x1, y1]];
   };
   projection.scale = function(_) {
-    return arguments.length ? (transform = scaleTranslate((k = +_) * sx, k * sy, tx, ty), reset()) : k;
+    return arguments.length ? (k = +_, reset()) : k;
   };
   projection.translate = function(_) {
-    return arguments.length ? (transform = scaleTranslate(k * sx, k * sy, tx = +_[0], ty = +_[1]), reset()) : [tx, ty];
+    return arguments.length ? (tx = +_[0], ty = +_[1], reset()) : [tx, ty];
   }
   projection.reflectX = function(_) {
-    return arguments.length ? (transform = scaleTranslate(k * (sx = _ ? -1 : 1), k * sy, tx, ty), reset()) : sx < 0;
+    return arguments.length ? (sx = _ ? -1 : 1, reset()) : sx < 0;
   };
   projection.reflectY = function(_) {
-    return arguments.length ? (transform = scaleTranslate(k * sx, k * (sy = _ ? -1 : 1), tx, ty), reset()) : sy < 0;
+    return arguments.length ? (sy = _ ? -1 : 1, reset()) : sy < 0;
   };
   projection.fitExtent = function(extent, object) {
     return fitExtent(projection, extent, object);

--- a/test/projection/identity-test.js
+++ b/test/projection/identity-test.js
@@ -1,0 +1,23 @@
+var tape = require("tape"),
+    d3 = require("../../");
+
+require("./projectionEqual");
+
+tape("identity(point) returns the point", function(test) {
+  var identity = d3.geoIdentity().translate([0, 0]).scale(1);
+  test.projectionEqual(identity, [   0,   0], [   0,   0]);
+  test.projectionEqual(identity, [-180,   0], [-180,   0]);
+  test.projectionEqual(identity, [ 180,   0], [ 180,   0]);
+  test.projectionEqual(identity, [  30,  30], [  30,  30]);
+  test.end();
+});
+
+
+tape("identity(point).scale(…).translate(…) returns the point", function(test) {
+  var identity = d3.geoIdentity().translate([100, 10]).scale(2);
+  test.projectionEqual(identity, [   0,   0], [ 100,  10]);
+  test.projectionEqual(identity, [-180,   0], [-260,  10]);
+  test.projectionEqual(identity, [ 180,   0], [ 460,  10]);
+  test.projectionEqual(identity, [  30,  30], [ 160,  70]);
+  test.end();
+});

--- a/test/projection/identity-test.js
+++ b/test/projection/identity-test.js
@@ -33,3 +33,22 @@ tape("identity(point).reflectX(…) and reflectY() return the transformed point"
   test.projectionEqual(identity.reflectY(false), [   3,   7], [ 106,  24]);
   test.end();
 });
+
+tape("geoPath(identity) returns the path", function(test) {
+  var identity = d3.geoIdentity().translate([0, 0]).scale(1),
+    path = d3.geoPath().projection(identity);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M0,0L10,10");
+  identity.translate([30,90]).scale(2).reflectY(true);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M30,90L50,70");
+  test.end();
+});
+
+tape("geoPath(identity) respects clipExtent", function(test) {
+  var identity = d3.geoIdentity().translate([0, 0]).scale(1),
+    path = d3.geoPath().projection(identity);
+  identity.clipExtent([[5,5], [40, 80]]);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M5,5L10,10");
+  identity.translate([30,90]).scale(2).reflectY(true).clipExtent([[35,76], [45, 86]]);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M35,85L44,76");
+  test.end();
+});

--- a/test/projection/identity-test.js
+++ b/test/projection/identity-test.js
@@ -13,11 +13,23 @@ tape("identity(point) returns the point", function(test) {
 });
 
 
-tape("identity(point).scale(…).translate(…) returns the point", function(test) {
+tape("identity(point).scale(…).translate(…) returns the transformed point", function(test) {
   var identity = d3.geoIdentity().translate([100, 10]).scale(2);
   test.projectionEqual(identity, [   0,   0], [ 100,  10]);
   test.projectionEqual(identity, [-180,   0], [-260,  10]);
   test.projectionEqual(identity, [ 180,   0], [ 460,  10]);
   test.projectionEqual(identity, [  30,  30], [ 160,  70]);
+  test.end();
+});
+
+
+tape("identity(point).reflectX(…) and reflectY() return the transformed point", function(test) {
+  var identity = d3.geoIdentity().translate([100, 10]).scale(2)
+    .reflectX(false).reflectY(false);
+  test.projectionEqual(identity, [   3,   7], [ 106,  24]);
+  test.projectionEqual(identity.reflectX(true), [   3,   7], [ 94,  24]);
+  test.projectionEqual(identity.reflectY(true), [   3,   7], [ 94,  -4]);
+  test.projectionEqual(identity.reflectX(false), [   3,   7], [ 106,  -4]);
+  test.projectionEqual(identity.reflectY(false), [   3,   7], [ 106,  24]);
   test.end();
 });


### PR DESCRIPTION
d3.geoIdentity can be used as a function and has an inverse

An alternative to https://github.com/d3/d3-geo/pull/183 to solve #182

I believe it's better, even though it has a (tiny) cost of not avoiding a multiplication by 1 when the scale is 1.

build at https://observablehq.com/d/0b817c9a2552c573 and test at https://observablehq.com/d/0b817c9a2552c573