### PR TITLE
Identity.angle

### DIFF
--- a/README.md
+++ b/README.md
@@ -650,7 +650,7 @@ function matrix(a, b, c, d, tx, ty) {
 
 <a href="#geoIdentity" name="geoIdentity">#</a> d3.<b>geoIdentity</b>() [<>](https://github.com/d3/d3-geo/blob/master/src/projection/identity.js "Source")
 
-The identity transform can be used to scale, translate and clip planar geometry. It implements [*projection*.scale](#projection_scale), [*projection*.translate](#projection_translate), [*projection*.fitExtent](#projection_fitExtent), [*projection*.fitSize](#projection_fitSize), [*projection*.fitWidth](#projection_fitWidth), [*projection*.fitHeight](#projection_fitHeight), [*projection*.clipExtent](#projection_clipExtent), [*projection*.reflectX](#projection_reflectX) and [*projection*.reflectY](#projection_reflectY).
+The identity transform can be used to scale, translate and clip planar geometry. It implements [*projection*.scale](#projection_scale), [*projection*.translate](#projection_translate), [*projection*.fitExtent](#projection_fitExtent), [*projection*.fitSize](#projection_fitSize), [*projection*.fitWidth](#projection_fitWidth), [*projection*.fitHeight](#projection_fitHeight), [*projection*.clipExtent](#projection_clipExtent), [*projection*.angle](#projection_angle), [*projection*.reflectX](#projection_reflectX) and [*projection*.reflectY](#projection_reflectY).
 
 ### Clipping
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ If *center* is specified, sets the projection’s center to the specified *cente
 
 If *angle* is specified, sets the projection’s post-projection planar rotation angle to the specified *angle* in degrees and returns the projection. If *angle* is not specified, returns the projection’s current angle, which defaults to 0°. Note that it may be faster to rotate during rendering (e.g., using [*context*.rotate](https://developer.mozilla.org/docs/Web/API/CanvasRenderingContext2D/rotate)) rather than during projection.
 
+<a href="#projection_reflectX" name="projection_reflectX">#</a> <i>projection</i>.<b>reflectX</b>([<i>reflect</i>])
+
+If *reflect* is specified, sets whether or not the *x*-dimension is reflected (negated) in the output. If *reflect* is not specified, returns true if *x*-reflection is enabled, which defaults to false. This can be useful to display sky and astronomical data with the orb seen from below: right ascension (eastern direction) will point to the left when North is pointing up.
+
+<a href="#projection_reflectY" name="projection_reflectY">#</a> <i>projection</i>.<b>reflectY</b>([<i>reflect</i>])
+
+If *reflect* is specified, sets whether or not the *y*-dimension is reflected (negated) in the output. If *reflect* is not specified, returns true if *y*-reflection is enabled, which defaults to false. This is especially useful for transforming from standard [spatial reference systems](https://en.wikipedia.org/wiki/Spatial_reference_system), which treat positive *y* as pointing up, to display coordinate systems such as Canvas and SVG, which treat positive *y* as pointing down.
+
 <a href="#projection_rotate" name="projection_rotate">#</a> <i>projection</i>.<b>rotate</b>([<i>angles</i>]) [<>](https://github.com/d3/d3-geo/blob/master/src/projection/index.js "Source")
 
 If *rotation* is specified, sets the projection’s [three-axis spherical rotation](https://bl.ocks.org/mbostock/4282586) to the specified *angles*, which must be a two- or three-element array of numbers [*lambda*, *phi*, *gamma*] specifying the rotation angles in degrees about [each spherical axis](https://bl.ocks.org/mbostock/4282586). (These correspond to [yaw, pitch and roll](https://en.wikipedia.org/wiki/Aircraft_principal_axes).) If the rotation angle *gamma* is omitted, it defaults to 0. See also [d3.geoRotation](#geoRotation). If *rotation* is not specified, returns the current rotation which defaults [0, 0, 0].
@@ -642,15 +650,7 @@ function matrix(a, b, c, d, tx, ty) {
 
 <a href="#geoIdentity" name="geoIdentity">#</a> d3.<b>geoIdentity</b>() [<>](https://github.com/d3/d3-geo/blob/master/src/projection/identity.js "Source")
 
-The identity transform can be used to scale, translate and clip planar geometry. It implements [*projection*.scale](#projection_scale), [*projection*.translate](#projection_translate), [*projection*.fitExtent](#projection_fitExtent), [*projection*.fitSize](#projection_fitSize), [*projection*.fitWidth](#projection_fitWidth), [*projection*.fitHeight](#projection_fitHeight) and [*projection*.clipExtent](#projection_clipExtent).
-
-<a href="#identity_reflectX" name="identity_reflectX">#</a> <i>identity</i>.<b>reflectX</b>([<i>reflect</i>])
-
-If *reflect* is specified, sets whether or not the *x*-dimension is reflected (negated) in the output. If *reflect* is not specified, returns true if *x*-reflection is enabled, which defaults to false.
-
-<a href="#identity_reflectY" name="identity_reflectY">#</a> <i>identity</i>.<b>reflectY</b>([<i>reflect</i>])
-
-If *reflect* is specified, sets whether or not the *y*-dimension is reflected (negated) in the output. If *reflect* is not specified, returns true if *y*-reflection is enabled, which defaults to false. This is especially useful for transforming from standard [spatial reference systems](https://en.wikipedia.org/wiki/Spatial_reference_system), which treat positive *y* as pointing up, to display coordinate systems such as Canvas and SVG, which treat positive *y* as pointing down.
+The identity transform can be used to scale, translate and clip planar geometry. It implements [*projection*.scale](#projection_scale), [*projection*.translate](#projection_translate), [*projection*.fitExtent](#projection_fitExtent), [*projection*.fitSize](#projection_fitSize), [*projection*.fitWidth](#projection_fitWidth), [*projection*.fitHeight](#projection_fitHeight), [*projection*.clipExtent](#projection_clipExtent), [*projection*.reflectX](#projection_reflectX) and [*projection*.reflectY](#projection_reflectY).
 
 ### Clipping
 

--- a/src/projection/identity.js
+++ b/src/projection/identity.js
@@ -3,60 +3,66 @@ import identity from "../identity.js";
 import {transformer} from "../transform.js";
 import {fitExtent, fitSize, fitWidth, fitHeight} from "./fit.js";
 
-function scaleTranslate(kx, ky, tx, ty) {
-  return kx === 1 && ky === 1 && tx === 0 && ty === 0 ? identity : transformer({
-    point: function(x, y) {
-      this.stream.point(x * kx + tx, y * ky + ty);
-    }
-  });
-}
-
 export default function() {
-  var k = 1, tx = 0, ty = 0, sx = 1, sy = 1, transform = identity, // scale, translate and reflect
+  var k = 1, tx = 0, ty = 0, sx = 1, sy = 1, // scale, translate and reflect
       x0 = null, y0, x1, y1, // clip extent
+      kx = 1, ky = 1,
+      transform = transformer({
+        point: function(x, y) {
+          var p = projection([x, y])
+          this.stream.point(p[0], p[1]);
+        }
+      }),
       postclip = identity,
       cache,
-      cacheStream,
-      projection;
+      cacheStream;
 
   function reset() {
+    kx = k * sx;
+    ky = k * sy;
     cache = cacheStream = null;
     return projection;
   }
 
-  return projection = {
-    stream: function(stream) {
-      return cache && cacheStream === stream ? cache : cache = transform(postclip(cacheStream = stream));
-    },
-    postclip: function(_) {
-      return arguments.length ? (postclip = _, x0 = y0 = x1 = y1 = null, reset()) : postclip;
-    },
-    clipExtent: function(_) {
-      return arguments.length ? (postclip = _ == null ? (x0 = y0 = x1 = y1 = null, identity) : clipRectangle(x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1]), reset()) : x0 == null ? null : [[x0, y0], [x1, y1]];
-    },
-    scale: function(_) {
-      return arguments.length ? (transform = scaleTranslate((k = +_) * sx, k * sy, tx, ty), reset()) : k;
-    },
-    translate: function(_) {
-      return arguments.length ? (transform = scaleTranslate(k * sx, k * sy, tx = +_[0], ty = +_[1]), reset()) : [tx, ty];
-    },
-    reflectX: function(_) {
-      return arguments.length ? (transform = scaleTranslate(k * (sx = _ ? -1 : 1), k * sy, tx, ty), reset()) : sx < 0;
-    },
-    reflectY: function(_) {
-      return arguments.length ? (transform = scaleTranslate(k * sx, k * (sy = _ ? -1 : 1), tx, ty), reset()) : sy < 0;
-    },
-    fitExtent: function(extent, object) {
-      return fitExtent(projection, extent, object);
-    },
-    fitSize: function(size, object) {
-      return fitSize(projection, size, object);
-    },
-    fitWidth: function(width, object) {
-      return fitWidth(projection, width, object);
-    },
-    fitHeight: function(height, object) {
-      return fitHeight(projection, height, object);
-    }
+  function projection (p) {
+    return [p[0] * kx + tx, p[1] * ky + ty];
+  }
+  projection.invert = function(p) {
+    return [(p[0] - tx) / kx, (p[1] - ty) / ky];
   };
+  projection.stream = function(stream) {
+    return cache && cacheStream === stream ? cache : cache = transform(postclip(cacheStream = stream));
+  };
+  projection.postclip = function(_) {
+    return arguments.length ? (postclip = _, x0 = y0 = x1 = y1 = null, reset()) : postclip;
+  };
+  projection.clipExtent = function(_) {
+    return arguments.length ? (postclip = _ == null ? (x0 = y0 = x1 = y1 = null, identity) : clipRectangle(x0 = +_[0][0], y0 = +_[0][1], x1 = +_[1][0], y1 = +_[1][1]), reset()) : x0 == null ? null : [[x0, y0], [x1, y1]];
+  };
+  projection.scale = function(_) {
+    return arguments.length ? (k = +_, reset()) : k;
+  };
+  projection.translate = function(_) {
+    return arguments.length ? (tx = +_[0], ty = +_[1], reset()) : [tx, ty];
+  }
+  projection.reflectX = function(_) {
+    return arguments.length ? (sx = _ ? -1 : 1, reset()) : sx < 0;
+  };
+  projection.reflectY = function(_) {
+    return arguments.length ? (sy = _ ? -1 : 1, reset()) : sy < 0;
+  };
+  projection.fitExtent = function(extent, object) {
+    return fitExtent(projection, extent, object);
+  };
+  projection.fitSize = function(size, object) {
+    return fitSize(projection, size, object);
+  };
+  projection.fitWidth = function(width, object) {
+    return fitWidth(projection, width, object);
+  };
+  projection.fitHeight = function(height, object) {
+    return fitHeight(projection, height, object);
+  };
+
+  return projection;
 }

--- a/src/projection/index.js
+++ b/src/projection/index.js
@@ -24,17 +24,18 @@ function transformRotate(rotate) {
   });
 }
 
-function scaleTranslate(k, dx, dy) {
+function scaleTranslate(k, dx, dy, sx, sy) {
   function transform(x, y) {
+    x *= sx; y *= sy;
     return [dx + k * x, dy - k * y];
   }
   transform.invert = function(x, y) {
-    return [(x - dx) / k, (dy - y) / k];
+    return [(x - dx) / k * sx, (dy - y) / k * sy];
   };
   return transform;
 }
 
-function scaleTranslateRotate(k, dx, dy, alpha) {
+function scaleTranslateRotate(k, dx, dy, sx, sy, alpha) {
   var cosAlpha = cos(alpha),
       sinAlpha = sin(alpha),
       a = cosAlpha * k,
@@ -44,10 +45,11 @@ function scaleTranslateRotate(k, dx, dy, alpha) {
       ci = (sinAlpha * dy - cosAlpha * dx) / k,
       fi = (sinAlpha * dx + cosAlpha * dy) / k;
   function transform(x, y) {
+    x *= sx; y *= sy;
     return [a * x - b * y + dx, dy - b * x - a * y];
   }
   transform.invert = function(x, y) {
-    return [ai * x - bi * y + ci, fi - bi * x - ai * y];
+    return [sx * (ai * x - bi * y + ci), sy * (fi - bi * x - ai * y)];
   };
   return transform;
 }
@@ -62,7 +64,9 @@ export function projectionMutator(projectAt) {
       x = 480, y = 250, // translate
       lambda = 0, phi = 0, // center
       deltaLambda = 0, deltaPhi = 0, deltaGamma = 0, rotate, // pre-rotate
-      alpha = 0, // post-rotate
+      alpha = 0, // post-rotate angle
+      sx = 1, // reflectX
+      sy = 1, // reflectX
       theta = null, preclip = clipAntimeridian, // pre-clip angle
       x0 = null, y0, x1, y1, postclip = identity, // post-clip extent
       delta2 = 0.5, // precision
@@ -121,6 +125,14 @@ export function projectionMutator(projectAt) {
     return arguments.length ? (alpha = _ % 360 * radians, recenter()) : alpha * degrees;
   };
 
+  projection.reflectX = function(_) {
+    return arguments.length ? (sx = _ ? -1 : 1, recenter()) : sx < 0;
+  };
+
+  projection.reflectY = function(_) {
+    return arguments.length ? (sy = _ ? -1 : 1, recenter()) : sy < 0;
+  };
+
   projection.precision = function(_) {
     return arguments.length ? (projectResample = resample(projectTransform, delta2 = _ * _), reset()) : sqrt(delta2);
   };
@@ -142,8 +154,8 @@ export function projectionMutator(projectAt) {
   };
 
   function recenter() {
-    var center = scaleTranslateRotate(k, 0, 0, alpha).apply(null, project(lambda, phi)),
-        transform = (alpha ? scaleTranslateRotate : scaleTranslate)(k, x - center[0], y - center[1], alpha);
+    var center = scaleTranslateRotate(k, 0, 0, sx, sy, alpha).apply(null, project(lambda, phi)),
+        transform = (alpha ? scaleTranslateRotate : scaleTranslate)(k, x - center[0], y - center[1], sx, sy, alpha);
     rotate = rotateRadians(deltaLambda, deltaPhi, deltaGamma);
     projectTransform = compose(project, transform);
     projectRotateTransform = compose(rotate, projectTransform);

--- a/test/projection/angle-test.js
+++ b/test/projection/angle-test.js
@@ -54,3 +54,13 @@ tape("projection.angle(…) wraps around 360°", function(test) {
   test.equal(projection.angle(), 0);
   test.end();
 });
+
+tape("identity.angle(…) rotates geoIdentity", function(test) {
+  var projection = d3.geoIdentity().angle(-45), SQRT2_2 = Math.sqrt(2) / 2;
+  test.inDelta(projection.angle(), -45);
+  test.projectionEqual(projection, [0, 0], [0, 0]);
+  test.projectionEqual(projection, [1, 0], [SQRT2_2, SQRT2_2]);
+  test.projectionEqual(projection, [-1, 0], [-SQRT2_2, -SQRT2_2]);
+  test.projectionEqual(projection, [0, 1], [-SQRT2_2, SQRT2_2]);
+  test.end();
+});

--- a/test/projection/identity-test.js
+++ b/test/projection/identity-test.js
@@ -1,0 +1,54 @@
+var tape = require("tape"),
+    d3 = require("../../");
+
+require("./projectionEqual");
+
+tape("identity(point) returns the point", function(test) {
+  var identity = d3.geoIdentity().translate([0, 0]).scale(1);
+  test.projectionEqual(identity, [   0,   0], [   0,   0]);
+  test.projectionEqual(identity, [-180,   0], [-180,   0]);
+  test.projectionEqual(identity, [ 180,   0], [ 180,   0]);
+  test.projectionEqual(identity, [  30,  30], [  30,  30]);
+  test.end();
+});
+
+
+tape("identity(point).scale(…).translate(…) returns the transformed point", function(test) {
+  var identity = d3.geoIdentity().translate([100, 10]).scale(2);
+  test.projectionEqual(identity, [   0,   0], [ 100,  10]);
+  test.projectionEqual(identity, [-180,   0], [-260,  10]);
+  test.projectionEqual(identity, [ 180,   0], [ 460,  10]);
+  test.projectionEqual(identity, [  30,  30], [ 160,  70]);
+  test.end();
+});
+
+
+tape("identity(point).reflectX(…) and reflectY() return the transformed point", function(test) {
+  var identity = d3.geoIdentity().translate([100, 10]).scale(2)
+    .reflectX(false).reflectY(false);
+  test.projectionEqual(identity, [   3,   7], [ 106,  24]);
+  test.projectionEqual(identity.reflectX(true), [   3,   7], [ 94,  24]);
+  test.projectionEqual(identity.reflectY(true), [   3,   7], [ 94,  -4]);
+  test.projectionEqual(identity.reflectX(false), [   3,   7], [ 106,  -4]);
+  test.projectionEqual(identity.reflectY(false), [   3,   7], [ 106,  24]);
+  test.end();
+});
+
+tape("geoPath(identity) returns the path", function(test) {
+  var identity = d3.geoIdentity().translate([0, 0]).scale(1),
+    path = d3.geoPath().projection(identity);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M0,0L10,10");
+  identity.translate([30,90]).scale(2).reflectY(true);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M30,90L50,70");
+  test.end();
+});
+
+tape("geoPath(identity) respects clipExtent", function(test) {
+  var identity = d3.geoIdentity().translate([0, 0]).scale(1),
+    path = d3.geoPath().projection(identity);
+  identity.clipExtent([[5,5], [40, 80]]);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M5,5L10,10");
+  identity.translate([30,90]).scale(2).reflectY(true).clipExtent([[35,76], [45, 86]]);
+  test.equal(path({type:"LineString", coordinates: [[0,0], [10,10]]}), "M35,85L44,76");
+  test.end();
+});

--- a/test/projection/reflect-test.js
+++ b/test/projection/reflect-test.js
@@ -1,0 +1,40 @@
+var tape = require("tape"),
+    d3 = require("../../");
+
+require("../inDelta");
+require("./projectionEqual");
+
+tape("projection.reflectX(…) defaults to false", function(test) {
+  var projection = d3.geoGnomonic().scale(1).translate([0, 0]);
+  test.equal(projection.reflectX(), false);
+  test.equal(projection.reflectY(), false);
+  test.projectionEqual(projection, [0, 0], [0, 0]);
+  test.projectionEqual(projection, [10, 0], [0.17632698070846498, 0]);
+  test.projectionEqual(projection, [0, 10], [0, -0.17632698070846498]);
+  test.end();
+});
+
+tape("projection.reflectX(…) mirrors x after projecting", function(test) {
+  var projection = d3.geoGnomonic().scale(1).translate([0, 0]).reflectX(true);
+  test.equal(projection.reflectX(), true);
+  test.projectionEqual(projection, [0, 0], [0, 0]);
+  test.projectionEqual(projection, [10, 0], [-0.17632698070846498, 0]);
+  test.projectionEqual(projection, [0, 10], [0, -0.17632698070846498]);
+  projection.reflectX(false).reflectY(true);
+  test.equal(projection.reflectX(), false);
+  test.equal(projection.reflectY(), true);
+  test.projectionEqual(projection, [0, 0], [0, 0]);
+  test.projectionEqual(projection, [10, 0], [0.17632698070846498, 0]);
+  test.projectionEqual(projection, [0, 10], [0, 0.17632698070846498]);
+  test.end();
+});
+
+tape("projection.reflectX(…) works with projection.angle()", function(test) {
+  var projection = d3.geoMercator().scale(1).translate([10, 20]).reflectX(true).angle(45);
+  test.equal(projection.reflectX(), true);
+  test.inDelta(projection.angle(), 45);
+  test.projectionEqual(projection, [0, 0], [10, 20]);
+  test.projectionEqual(projection, [10, 0], [9.87658658, 20.12341341]);
+  test.projectionEqual(projection, [0, 10], [9.87595521, 19.87595521]);
+  test.end();
+});


### PR DESCRIPTION
Implements *identity*.angle().

This PR is on top of #184 and #185. Its brings *geoIdentity* to parity with the other projections: all of them have now have the *reflectX*, *reflectY* and *angle* methods.

This carries to projections in d3-geo-polygon and d3-geo-projection “out of the box” once they upgrade to this branch of d3-geo.