### PR TITLE
conicEqualArea inverse was wrong for some parallels

### DIFF
--- a/src/projection/conicConformal.js
+++ b/src/projection/conicConformal.js
@@ -1,4 +1,4 @@
-import {abs, atan, atan2, cos, epsilon, halfPi, log, pow, sign, sin, sqrt, tan} from "../math.js";
+import {abs, atan, atan2, cos, epsilon, halfPi, log, pi, pow, sign, sin, sqrt, tan} from "../math.js";
 import {conicProjection} from "./conic.js";
 import {mercatorRaw} from "./mercator.js";
 
@@ -21,8 +21,11 @@ export function conicConformalRaw(y0, y1) {
   }
 
   project.invert = function(x, y) {
-    var fy = f - y, r = sign(n) * sqrt(x * x + fy * fy);
-    return [atan2(x, abs(fy)) / n * sign(fy), 2 * atan(pow(f / r, 1 / n)) - halfPi];
+    var fy = f - y, r = sign(n) * sqrt(x * x + fy * fy),
+      l = atan2(x, abs(fy)) * sign(fy);
+    if (fy * n < 0)
+      l -= pi * sign(x) * sign(fy);
+    return [l / n, 2 * atan(pow(f / r, 1 / n)) - halfPi];
   };
 
   return project;

--- a/src/projection/conicEqualArea.js
+++ b/src/projection/conicEqualArea.js
@@ -1,4 +1,4 @@
-import {abs, asin, atan2, cos, epsilon, sign, sin, sqrt} from "../math.js";
+import {abs, asin, atan2, cos, epsilon, pi, sign, sin, sqrt} from "../math.js";
 import {conicProjection} from "./conic.js";
 import {cylindricalEqualAreaRaw} from "./cylindricalEqualArea.js";
 
@@ -16,8 +16,11 @@ export function conicEqualAreaRaw(y0, y1) {
   }
 
   project.invert = function(x, y) {
-    var r0y = r0 - y;
-    return [atan2(x, abs(r0y)) / n * sign(r0y), asin((c - (x * x + r0y * r0y) * n * n) / (2 * n))];
+    var r0y = r0 - y,
+        l = atan2(x, abs(r0y)) * sign(r0y);
+    if (r0y * n < 0)
+      l -= pi * sign(x) * sign(r0y);
+    return [l / n, asin((c - (x * x + r0y * r0y) * n * n) / (2 * n))];
   };
 
   return project;

--- a/src/projection/conicEquidistant.js
+++ b/src/projection/conicEquidistant.js
@@ -1,4 +1,4 @@
-import {abs, atan2, cos, epsilon, sign, sin, sqrt} from "../math.js";
+import {abs, atan2, cos, epsilon, pi, sign, sin, sqrt} from "../math.js";
 import {conicProjection} from "./conic.js";
 import {equirectangularRaw} from "./equirectangular.js";
 
@@ -15,8 +15,11 @@ export function conicEquidistantRaw(y0, y1) {
   }
 
   project.invert = function(x, y) {
-    var gy = g - y;
-    return [atan2(x, abs(gy)) / n * sign(gy), g - sign(n) * sqrt(x * x + gy * gy)];
+    var gy = g - y,
+        l = atan2(x, abs(gy)) * sign(gy);
+    if (gy * n < 0)
+      l -= pi * sign(x) * sign(gy);
+    return [l / n, g - sign(n) * sqrt(x * x + gy * gy)];
   };
 
   return project;

--- a/test/projection/invert-test.js
+++ b/test/projection/invert-test.js
@@ -21,6 +21,7 @@ require("./projectionEqual");
   function conicEquidistant() { return d3.geoConicEquidistant().parallels([20, 30]); },
   function conicEquidistant() { return d3.geoConicEquidistant().parallels([30, 30]); },
   function conicEquidistant() { return d3.geoConicEquidistant().parallels([-35, -50]); },
+  function conicEquidistant() { return d3.geoConicEquidistant().parallels([40, 60]).rotate([-120,0]); },
   d3.geoEquirectangular,
   d3.geoEqualEarth,
   d3.geoGnomonic,

--- a/test/projection/invert-test.js
+++ b/test/projection/invert-test.js
@@ -11,6 +11,7 @@ require("./projectionEqual");
   function conicConformal() { return d3.geoConicConformal().parallels([20, 30]); },
   function conicConformal() { return d3.geoConicConformal().parallels([30, 30]); },
   function conicConformal() { return d3.geoConicConformal().parallels([-35, -50]); },
+  function conicConformal() { return d3.geoConicConformal().parallels([40, 60]).rotate([-120,0]); },
   d3.geoConicEqualArea,
   function conicEqualArea() { return d3.geoConicEqualArea().parallels([20, 30]); },
   function conicEqualArea() { return d3.geoConicEqualArea().parallels([-30, 30]); },

--- a/test/projection/invert-test.js
+++ b/test/projection/invert-test.js
@@ -15,6 +15,7 @@ require("./projectionEqual");
   function conicEqualArea() { return d3.geoConicEqualArea().parallels([20, 30]); },
   function conicEqualArea() { return d3.geoConicEqualArea().parallels([-30, 30]); },
   function conicEqualArea() { return d3.geoConicEqualArea().parallels([-35, -50]); },
+  function conicEqualArea() { return d3.geoConicEqualArea().parallels([40, 60]).rotate([-120,0]); },
   d3.geoConicEquidistant,
   function conicEquidistant() { return d3.geoConicEquidistant().parallels([20, 30]); },
   function conicEquidistant() { return d3.geoConicEquidistant().parallels([30, 30]); },


### PR DESCRIPTION
for example:
d3.geoConicEqualArea().parallels([-35, -50]) or
d3.geoConicEqualArea().parallels([35, 50])

at [175, 0]

(see https://observablehq.com/d/f087f9fe1c3ac997)