### PR TITLE
When calculating center use simpler transform where posssible.

### DIFF
--- a/src/projection/index.js
+++ b/src/projection/index.js
@@ -154,8 +154,14 @@ export function projectionMutator(projectAt) {
   };
 
   function recenter() {
-    var center = scaleTranslateRotate(k, 0, 0, sx, sy, alpha).apply(null, project(lambda, phi)),
-        transform = (alpha ? scaleTranslateRotate : scaleTranslate)(k, x - center[0], y - center[1], sx, sy, alpha);
+    var center, transform;
+    if(alpha) {
+      center = scaleTranslateRotate(k, 0, 0, sx, sy, alpha).apply(null, project(lambda, phi)),
+      transform = scaleTranslateRotate(k, x - center[0], y - center[1], sx, sy, alpha);
+    } else {
+      center = scaleTranslate(k, 0, 0, sx, sy).apply(null, project(lambda, phi)),
+      transform = scaleTranslate(k, x - center[0], y - center[1], sx, sy);
+    }
     rotate = rotateRadians(deltaLambda, deltaPhi, deltaGamma);
     projectTransform = compose(project, transform);
     projectRotateTransform = compose(rotate, projectTransform);


### PR DESCRIPTION
Hi, I have a minor code consistency issue

looking at the assignment of the variable "transform"

The is an existing  little optimisation which is can described as 

if  alpha 
     transform = a VERY expensive to calculate function of both translation and rotation
else // alpha is 0 
    transform = a LESS expensive calculation of just only translation.

The consistence comes by looking  the old definition of "center"

center always uses the most expensive calculation when sometimes the cheap function is possible

Anyway, I hope this helps.

Tests pass and my code is faster by a small amount -- 1%
