### PR TITLE
Minor fix. Fix incorrectly labelled d3.geoRotation() unit test.

### DIFF
--- a/test/rotation-test.js
+++ b/test/rotation-test.js
@@ -24,7 +24,7 @@ tape("a rotation of [-45°, -45°] rotates longitude and latitude", function(tes
   test.end();
 });
 
-tape("a rotation of [-45°, -45°] inverse rotation of longitude and latitude", function(test) {
+tape("a rotation of [-45°, 45°] inverse rotation of longitude and latitude", function(test) {
   var rotation = d3.geoRotation([-45, 45]).invert([-54.73561, 30]);
   test.inDelta(rotation[0], 0, 1e-6);
   test.inDelta(rotation[1], 0, 1e-6);


### PR DESCRIPTION
I am porting d3-geo to RUST .. 

So I am going over the code line by line.
I am also porting over the units  tests .. and noticed this little correction.. I want my code to be a close as possible to the original and still be correct - so this is a upstream fix.

a) The unit test description talks about a rotation of [+45, +45]
b) The unit test then tests a rotation of [-45, +45]

Note the mismatching minus sign.

I hope this is quick to review and fix.

