### PR TITLE
normalize angles in forwardRotationLambda

### DIFF
--- a/src/rotation.js
+++ b/src/rotation.js
@@ -2,7 +2,8 @@ import compose from "./compose.js";
 import {abs, asin, atan2, cos, degrees, pi, radians, sin, tau} from "./math.js";
 
 function rotationIdentity(lambda, phi) {
-  return [abs(lambda) > pi ? lambda + Math.round(-lambda / tau) * tau : lambda, phi];
+  if (abs(lambda) > pi) lambda -= Math.round(lambda / tau) * tau;
+  return [lambda, phi];
 }
 
 rotationIdentity.invert = rotationIdentity;
@@ -16,7 +17,9 @@ export function rotateRadians(deltaLambda, deltaPhi, deltaGamma) {
 
 function forwardRotationLambda(deltaLambda) {
   return function(lambda, phi) {
-    return lambda += deltaLambda, [lambda > pi ? lambda - tau : lambda < -pi ? lambda + tau : lambda, phi];
+    lambda += deltaLambda;
+    if (abs(lambda) > pi) lambda -= Math.round(lambda / tau) * tau;
+    return [lambda, phi];
   };
 }
 


### PR DESCRIPTION
Currently forwardRotationLambda only normalizes output longitudes between [-3π, 3π]; outside that range longitudes are only adjusted by 2π, however far they are from 0. See https://github.com/d3/d3-geo/issues/242