### PR TITLE
Minor: Unit tests for graticule.extentMinor() & graticule.extentMajor() 

### DIFF
--- a/test/graticule-test.js
+++ b/test/graticule-test.js
@@ -7,9 +7,9 @@ it("graticule.extent(…) sets extentMinor and extentMajor", () => {
   assert.deepStrictEqual(g.extentMinor(), [[-90, -45], [90, 45]]);
   assert.deepStrictEqual(g.extentMajor(), [[-90, -45], [90, 45]]);
 
-  const g_reversed = geoGraticule().extent([[90, 45], [-90, -45]]);
-  assert.deepStrictEqual(g_reversed.extentMinor(), [[-90, -45], [90, 45]]);
-  assert.deepStrictEqual(g_reversed.extentMajor(), [[-90, -45], [90, 45]]);
+  const gReversed = geoGraticule().extent([[90, 45], [-90, -45]]);
+  assert.deepStrictEqual(gReversed.extentMinor(), [[-90, -45], [90, 45]]);
+  assert.deepStrictEqual(gReversed.extentMajor(), [[-90, -45], [90, 45]]);
 });
 
 it("graticule.extent() gets extentMinor", () => {

--- a/test/graticule-test.js
+++ b/test/graticule-test.js
@@ -10,7 +10,6 @@ it("graticule.extent(…) sets extentMinor and extentMajor", () => {
   const g_reversed = geoGraticule().extent([[90, 45], [-90, -45]]);
   assert.deepStrictEqual(g_reversed.extentMinor(), [[-90, -45], [90, 45]]);
   assert.deepStrictEqual(g_reversed.extentMajor(), [[-90, -45], [90, 45]]);
-
 });
 
 it("graticule.extent() gets extentMinor", () => {

--- a/test/graticule-test.js
+++ b/test/graticule-test.js
@@ -6,6 +6,11 @@ it("graticule.extent(…) sets extentMinor and extentMajor", () => {
   const g = geoGraticule().extent([[-90, -45], [90, 45]]);
   assert.deepStrictEqual(g.extentMinor(), [[-90, -45], [90, 45]]);
   assert.deepStrictEqual(g.extentMajor(), [[-90, -45], [90, 45]]);
+
+  const g_reversed = geoGraticule().extent([[90, 45], [-90, -45]]);
+  assert.deepStrictEqual(g_reversed.extentMinor(), [[-90, -45], [90, 45]]);
+  assert.deepStrictEqual(g_reversed.extentMajor(), [[-90, -45], [90, 45]]);
+
 });
 
 it("graticule.extent() gets extentMinor", () => {


### PR DESCRIPTION
Looking at the bound checks of the form `if (x0 > x1)` in graticule.extentMinor() and graticle.extentMajor() would benifit some a simple extention to the unit testing.


```
  graticule.extentMinor = function (_) {
    if (!arguments.length) return [[x0, y0], [x1, y1]];
    x0 = +_[0][0], x1 = +_[1][0];
    y0 = +_[0][1], y1 = +_[1][1];
    if (x0 > x1) _ = x0, x0 = x1, x1 = _;
    if (y0 > y1) _ = y0, y0 = y1, y1 = _;
    return graticule.precision(precision);
  };
```

I am porting this code rust and I was looking at the code coverage reports. 
I can say this is a minor addition - with a very small bump in code coverage.

I just want the two code bases to keep in sync .. so from my point of view 
this is an upstream push.

