### PR TITLE
Fix: Coerce string coordinates to numbers in boundsPoint function #278

### DIFF
--- a/src/path/bounds.js
+++ b/src/path/bounds.js
@@ -19,8 +19,8 @@ var boundsStream = {
 };
 
 function boundsPoint(x, y) {
-  x = +x; // Coerce x to a number
-  y = +y; // Coerce y to a number
+  x = +x;
+  y = +y;
   if (x < x0) x0 = x;
   if (x > x1) x1 = x;
   if (y < y0) y0 = y;

--- a/src/path/bounds.js
+++ b/src/path/bounds.js
@@ -19,6 +19,8 @@ var boundsStream = {
 };
 
 function boundsPoint(x, y) {
+  x = +x; // Coerce x to a number
+  y = +y; // Coerce y to a number
   if (x < x0) x0 = x;
   if (x > x1) x1 = x;
   if (y < y0) y0 = y;


### PR DESCRIPTION
This pull request addresses issue #278, where `path.bounds` should return numbers even when input coordinates are strings. 

I have modified the `boundsPoint` function to coerce input coordinates to numbers. I tested the changes, and they successfully return numerical bounds for both string and number inputs.